### PR TITLE
compiler: remove `Copy` derive from generated core and config

### DIFF
--- a/rv64/src/raw.rs
+++ b/rv64/src/raw.rs
@@ -7,8 +7,8 @@ use softcore_prelude::*;
 /// This struct represents a software core, and holds all the registers as well as the core configuration.
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
-/// The raw functions translated directly from the specification are available in the [raw] module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+/// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub PC: xlenbits,
     pub nextPC: xlenbits,
@@ -166,13 +166,13 @@ pub struct Core {
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
     pub extensions: ConfigExtensions,
     pub memory: ConfigMemory,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigExtensions {
     pub A: ConfigA,
     pub B: ConfigB,
@@ -232,292 +232,292 @@ pub struct ConfigExtensions {
     pub Zvksh: ConfigZvksh,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigA {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigB {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigFD {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigM {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigS {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigSmcntrpmf {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigSscofpmf {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigSstc {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigSv32 {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigSv39 {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigSv48 {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigSv57 {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigSvbare {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigSvinval {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigU {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigV {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZaamo {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZabha {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZalrsc {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZba {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZbb {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZbc {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZbkb {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZbkc {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZbkx {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZbs {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZca {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZcb {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZcd {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZcf {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZcmop {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZfa {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZfh {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZfhmin {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZfinx {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZhinx {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZicbom {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZicboz {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZicntr {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZicond {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZifencei {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZihpm {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZimop {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZknd {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZkne {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZknh {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZkr {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZksed {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZksh {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZmmul {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZvbb {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZvbc {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZvkb {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZvknha {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZvknhb {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigZvksh {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigMemory {
     pub pmp: ConfigPmp,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigPmp {
     pub grain: usize,
 }

--- a/sail_rust_backend/rust_backend.ml
+++ b/sail_rust_backend/rust_backend.ml
@@ -640,6 +640,7 @@ module Codegen () = struct
                 name = enum_name;
                 generics = [];
                 fields =  List.map (fun id -> (id, None)) enum_fields; 
+                derive = default_copy_derive;
                 doc = [
                     enum_name;
                     "";
@@ -683,6 +684,7 @@ module Codegen () = struct
             name = id;
             generics = typequant_to_generics typq;
             fields = process_unions members;
+            derive = default_copy_derive;
             doc = [
                 id;
                 "";
@@ -699,6 +701,7 @@ module Codegen () = struct
             name = id;
             generics = typequant_to_generics typeq;
             fields = List.map to_rs_fields fields;
+            derive = default_copy_derive;
             doc = [
                 id;
                 "";
@@ -818,6 +821,7 @@ module Codegen () = struct
                 name = "Core";
                 generics = [];
                 fields = (gather_registers defs) @ config_field;
+                derive = ["Eq"; "PartialEq"; "Clone"; "Debug"];
                 doc = [
                     "The software core.";
                     "";

--- a/tests/basic/src/arch.rs
+++ b/tests/basic/src/arch.rs
@@ -8,7 +8,7 @@ use softcore_prelude::*;
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
 /// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub PC: xlenbits,
     pub nextPC: xlenbits,
@@ -16,7 +16,7 @@ pub struct Core {
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
 
 }

--- a/tests/basic_alt/src/arch.rs
+++ b/tests/basic_alt/src/arch.rs
@@ -8,7 +8,7 @@ use softcore_prelude::*;
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
 /// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub PC: xlenbits,
     pub nextPC: xlenbits,
@@ -16,7 +16,7 @@ pub struct Core {
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
 
 }

--- a/tests/config/src/arch.rs
+++ b/tests/config/src/arch.rs
@@ -8,29 +8,29 @@ use softcore_prelude::*;
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
 /// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub PC: xlenbits,
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
     pub extensions: ConfigExtensions,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigExtensions {
     pub S: ConfigS,
     pub U: ConfigU,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigS {
     pub supported: bool,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct ConfigU {
     pub supported: bool,
 }

--- a/tests/csr/src/arch.rs
+++ b/tests/csr/src/arch.rs
@@ -8,7 +8,7 @@ use softcore_prelude::*;
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
 /// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub PC: xlenbits,
     pub nextPC: xlenbits,
@@ -19,7 +19,7 @@ pub struct Core {
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
 
 }

--- a/tests/hoisting/src/arch.rs
+++ b/tests/hoisting/src/arch.rs
@@ -8,13 +8,13 @@ use softcore_prelude::*;
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
 /// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub PC: xlenbits,
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
 
 }

--- a/tests/mret/src/arch.rs
+++ b/tests/mret/src/arch.rs
@@ -8,7 +8,7 @@ use softcore_prelude::*;
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
 /// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub PC: xlenbits,
     pub nextPC: xlenbits,
@@ -21,7 +21,7 @@ pub struct Core {
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
 
 }

--- a/tests/trap/src/arch.rs
+++ b/tests/trap/src/arch.rs
@@ -8,7 +8,7 @@ use softcore_prelude::*;
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
 /// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub PC: xlenbits,
     pub nextPC: xlenbits,
@@ -33,7 +33,7 @@ pub struct Core {
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
 
 }

--- a/tests/types/src/arch.rs
+++ b/tests/types/src/arch.rs
@@ -8,12 +8,12 @@ use softcore_prelude::*;
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
 /// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
     pub unknown_at_compile_time: usize,
 }

--- a/tests/wfi/src/arch.rs
+++ b/tests/wfi/src/arch.rs
@@ -8,7 +8,7 @@ use softcore_prelude::*;
 /// The core is the main abstraction exposed by the softcore library and represents a single execution thread.
 /// 
 /// The raw functions translated directly from the specification are available in the `raw` module, whereas higher-level wrappers are implemented as methods on the [Core] struct directly.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Core {
     pub mepc: xlenbits,
     pub sepc: xlenbits,
@@ -21,7 +21,7 @@ pub struct Core {
     pub config: Config,
 }
 
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Config {
 
 }


### PR DESCRIPTION
We use copy semantic for all Sail values, as they are mostly small bit vectors and that makes borrow checking much simpler, however we used to derive Copy for all structs, including the giant Core structure holding all the registers of the model.
This commit adds a `derive` fields to structs in the compiler to allow selecting the traits to derive on a per-struct basis. Using this, we no longer derive Copy for the Core and Config structs.