### PR TITLE
Add support for CSR write operations to RV64 model

### DIFF
--- a/rv64/src/config.rs
+++ b/rv64/src/config.rs
@@ -6,6 +6,7 @@
 //! PRs to contribute new configurations for popular cores are welcome.
 
 use crate::raw;
+use softcore_prelude::BitVector;
 
 /// A configuration with all extensions disabled.
 pub const MINIMAL: raw::Config = raw::Config {
@@ -69,6 +70,11 @@ pub const MINIMAL: raw::Config = raw::Config {
         Zvknha: raw::ConfigZvknha { supported: false },
         Zvknhb: raw::ConfigZvknhb { supported: false },
         Zvksh: raw::ConfigZvksh { supported: false },
+    },
+    base: raw::ConfigBase {
+        writable_fiom: false,
+        writable_hpm_counters: BitVector::new(0),
+        writable_misa: false,
     },
     memory: raw::ConfigMemory {
         pmp: raw::ConfigPmp { count: 0, grain: 0 },
@@ -137,6 +143,11 @@ pub const U74: raw::Config = raw::Config {
         Zvknha: raw::ConfigZvknha { supported: false },
         Zvknhb: raw::ConfigZvknhb { supported: false },
         Zvksh: raw::ConfigZvksh { supported: false },
+    },
+    base: raw::ConfigBase {
+        writable_fiom: true,
+        writable_hpm_counters: BitVector::new(0), // TODO: check on a board
+        writable_misa: false,
     },
     memory: raw::ConfigMemory {
         pmp: raw::ConfigPmp {

--- a/sail_rust_backend/call_set.ml
+++ b/sail_rust_backend/call_set.ml
@@ -208,6 +208,8 @@ let rec get_call_set (ast : (tannot, env) ast) : sail_ctx =
       ; "exceptionType_to_bits"
       ; (* CSRs *)
         "read_CSR"
+      ; "write_CSR"
+      ; "doCSR"
       ]
   in
   let sail_ctx = { call_set; config_map = SMap.empty } in

--- a/sail_rust_backend/rust_transform.ml
+++ b/sail_rust_backend/rust_transform.ml
@@ -670,6 +670,7 @@ let unsupported_fun : SSet.t =
     ; "csr_id_write_callback"
     ; "csr_full_write_callback"
     ; "long_csr_write_callback"
+    ; "hex_bits_forwards"
     ]
 ;;
 
@@ -1363,6 +1364,7 @@ let prelude_func : SSet.t =
     ; "sign_extend"
     ; "sail_ones"
     ; "internal_error"
+    ; "hex_bits_forwards"
     ; "hex_bits_12_forwards"
     ; "hex_bits_12_backwards"
     ; "parse_hex_bits"

--- a/tests/trap/arch.rs
+++ b/tests/trap/arch.rs
@@ -508,10 +508,7 @@ pub fn exception_delegatee(core_ctx: &mut Core, e: ExceptionType, p: Privilege) 
         let var_1 = bitvector_access(core_ctx.medeleg.bits, idx);
         bit_to_bool(var_1)
     };
-    let user = false;
-    let deleg = if {user} {
-        Privilege::User
-    } else if {_super_} {
+    let deleg = if {_super_} {
         Privilege::Supervisor
     } else {
         Privilege::Machine

--- a/tests/types/arch.rs
+++ b/tests/types/arch.rs
@@ -206,8 +206,6 @@ pub fn exceptionType_to_bits(e: ExceptionType) -> BitVector<8> {
 /// Generated from the Sail sources at `tests/types/arch.sail` L136-178.
 pub fn execute_TEST(core_ctx: &mut Core) {
     let a = handle_int(1234);
-    let b = false;
-    let c = 131;
     let d = handle_retired(());
     let e = handle_union(());
     let f = hex_bits_backwards(8, "00");


### PR DESCRIPTION
This PR expend the compiler to support enough optimization so we can translate the CSR write operations to Rust. The RV64 model can now perform all CSR operations (CSRRW, CSRRS, CSRRC, CSRRWI, CSRRSI, and CSRRCI).

This should open the door to proper verification in system software. The next step is to start experimenting with the RV64 model in [Miralis](https://github.com/CharlyCst/miralis) to see if we can replace the existing tests using the VirtContext with a proper RISC-V core.