### PR TITLE
Improve Armv9-A support (still experimental)

### DIFF
--- a/armv9a/src/arch_prelude.rs
+++ b/armv9a/src/arch_prelude.rs
@@ -21,7 +21,7 @@ pub fn ZeroExtend0<const N: i128, const M: i128>(bits: BitVector<N>, m: i128) ->
 
 pub fn SignExtend0<const N: i128, const M: i128>(bits: BitVector<N>, m: i128) -> BitVector<M> {
     assert_eq!(m, M, "ZeroExtend0 with the wring bit width");
-    bits.
+    sign_extend(m, bits)
 }
 
 pub const fn emod_nat(n: i128, m: i128) -> i128 {

--- a/prelude/src/lib.rs
+++ b/prelude/src/lib.rs
@@ -39,6 +39,15 @@ pub const fn get_slice_int<const L: i128>(l: i128, n: i128, start: i128) -> BitV
     bv(val as u64)
 }
 
+pub const fn slice<const N: i128, const M: i128>(
+    bits: BitVector<M>,
+    start: i128,
+    len: i128,
+) -> BitVector<N> {
+    let mask = mask(len as usize);
+    bv((bits.bits() >> start) & mask)
+}
+
 pub fn get_16_random_bits(_unit: ()) -> BitVector<16> {
     bv::<16>(0)
 }
@@ -73,22 +82,19 @@ pub fn truncate(v: BitVector<64>, size: i128) -> BitVector<64> {
     v
 }
 
-pub fn sign_extend<const M: i128, const N: i128>(
-    value: i128,
-    input: BitVector<M>,
-) -> BitVector<N> {
+pub fn sign_extend<const M: i128, const N: i128>(value: i128, input: BitVector<M>) -> BitVector<N> {
     assert!(value == N, "Mismatch `sign_extend` size");
     assert!(N >= M, "Cannot sign extend to smaller size");
     assert!(N <= 64, "Maximum supported size is 64 for now");
-    
+
     // Special case: when extending from same size to same size, it's a no-op
     if M == N {
         return bv::<N>(input.bits());
     }
-    
+
     // Check if the sign bit (MSB) is set
     let sign_bit = (input.bits() >> (M - 1)) & 1;
-    
+
     if sign_bit == 0 {
         // Positive number - just zero extend
         bv::<N>(input.bits())
@@ -743,7 +749,7 @@ mod tests {
         let input = bv::<4>(0b0111); // 7 in 4 bits
         let result = sign_extend::<4, 8>(8, input);
         assert_eq!(result.bits(), 0b00000111); // Should remain 7 in 8 bits
-        
+
         // Test sign extending negative values from 4 to 8 bits
         let input = bv::<4>(0b1000); // -8 in 4 bits (two's complement)
         let result = sign_extend::<4, 8>(8, input);

--- a/sail_rust_backend/arch/armv9a.ml
+++ b/sail_rust_backend/arch/armv9a.ml
@@ -5,8 +5,10 @@ let call_set =
     [ (* Integer arithmetics *)
       "execute_aarch64_instrs_integer_arithmetic_add_sub_carry"
     ; "execute_aarch64_instrs_integer_arithmetic_add_sub_immediate"
-    (* ; "execute_aarch64_instrs_integer_arithmetic_add_sub_extendedreg" *)
-    (* ; "execute_aarch64_instrs_integer_arithmetic_add_sub_shiftedreg" *)
+      (* ; "execute_aarch64_instrs_integer_arithmetic_add_sub_extendedreg" *)
+      (* ; "execute_aarch64_instrs_integer_arithmetic_add_sub_shiftedreg" *)
+    ; (* System registers *)
+      (* "execute_aarch64_instrs_system_register_system_128" *)
     ]
 ;;
 
@@ -49,4 +51,5 @@ let unsupported_obj : SSet.t =
     ]
 ;;
 
-let armv9a : Types.arch_t = { call_set; external_func; unsupported_obj }
+let unsupported_func : SSet.t = SSet.of_list [ "NVMem_read__1" ]
+let armv9a : Types.arch_t = { call_set; external_func; unsupported_obj; unsupported_func }

--- a/sail_rust_backend/arch/rv64.ml
+++ b/sail_rust_backend/arch/rv64.ml
@@ -98,4 +98,5 @@ let unsupported_obj : SSet.t =
     ]
 ;;
 
-let rv64 : Types.arch_t = { call_set; external_func; unsupported_obj }
+let unsupported_func : SSet.t = SSet.of_list []
+let rv64 : Types.arch_t = { call_set; external_func; unsupported_obj; unsupported_func }

--- a/sail_rust_backend/rust_gen.ml
+++ b/sail_rust_backend/rust_gen.ml
@@ -374,8 +374,8 @@ let sanitize_generic_id (id : string) : string =
   else id
 ;;
 
-let quote_regexp = Str.regexp "'"
-let qmark_regexp = Str.regexp "\?"
+let quote_regexp = Str.regexp_string "'"
+let qmark_regexp = Str.regexp_string "?"
 
 (** Turn a Sail ID into a valid Rust id.
 

--- a/sail_rust_backend/rust_transform.ml
+++ b/sail_rust_backend/rust_transform.ml
@@ -653,9 +653,9 @@ let native_func_transform_exp (ctx : context) (exp : rs_exp) : rs_exp =
   | RsApp (RsId "not_vec", gens, [ v ]) -> RsUnop (RsUnopNot, v)
   | RsApp (RsId "eq_bit", gens, [ e1; e2 ]) ->
     RsBinop (e1, RsBinopEq, e2) (* TODO Is it correct to compare like that? *)
-  | RsApp (RsId "eq_bool", gens, _) -> RsId "BUILTIN_eq_bool_TODO"
-  | RsApp (RsId "eq_string", gens, _) -> RsId "BUILTIN_eq_string_TODO"
-  | RsApp (RsId "eq_int", gens, _) -> RsId "BUILTIN_eq_int_TODO"
+  | RsApp (RsId "eq_bool", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopEq, e2)
+  | RsApp (RsId "eq_string", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopEq, e2)
+  | RsApp (RsId "eq_int", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopEq, e2)
   | RsApp (RsId "not", gens, [ b ]) -> RsUnop (RsUnopNot, b)
   | RsApp (RsId "lt", gens, _) -> RsId "BUILTIN_lt_TODO"
   | RsApp (RsId "lteq", gens, _) -> RsId "BUILTIN_lteq_TODO"
@@ -669,7 +669,7 @@ let native_func_transform_exp (ctx : context) (exp : rs_exp) : rs_exp =
   | RsApp (RsId "abs_int", gens, _) -> RsId "BUILTIN_abs_int_TODO"
   | RsApp (RsId "max_int", gens, _) -> RsId "BUILTIN_max_int_TODO"
   (*| RsApp (RsId "min_int", gens, _) -> RsId "BUILTIN_min_int_TODO" *)
-  | RsApp (RsId "tdiv_int", gens, _) -> RsId "BUILTIN_tdiv_int_TODO"
+  | RsApp (RsId "tdiv_int", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopDiv, e2)
   | RsApp (RsId "tmod_int", gens, _) -> RsId "BUILTIN_tmod_int_TODO"
   | RsApp (RsId "pow2", [], [ n ]) ->
     RsApp
@@ -683,7 +683,7 @@ let native_func_transform_exp (ctx : context) (exp : rs_exp) : rs_exp =
     | RsApp (RsId "sail_ones", gens, e) -> RsApp (RsId "sail_ones", e) *)
   | RsApp (RsId "sail_signed", gens, _) -> RsId "BUILTIN_sail_signed_TODO"
   | RsApp (RsId "sail_unsigned", gens, _) -> RsId "BUILTIN_sail_unsigned_TODO"
-  | RsApp (RsId "slice", gens, _) -> RsId "BUILTIN_slice_TODO"
+  | RsApp (RsId "slice", gens, args) -> RsApp (RsId "slice", [], args)
   | RsApp (RsId "slice_inc", gens, _) -> RsId "BUILTIN_slice_inc_TODO"
   | RsApp (RsId "add_bits", gens, _) -> RsId "BUILTIN_add_bits_TODO"
   | RsApp (RsId "add_bits_int", gens, [ b1; b2 ]) -> RsBinop (b1, RsBinopAdd, b2)

--- a/sail_rust_backend/types.ml
+++ b/sail_rust_backend/types.ml
@@ -6,4 +6,5 @@ type arch_t =
   { call_set : SSet.t
   ; external_func : SSet.t
   ; unsupported_obj : SSet.t
+  ; unsupported_func: SSet.t
   }


### PR DESCRIPTION
This PR improves the Armv9-A in fixing some built-in issues and introducing the ability to specify per-architecture unsupported functions.

Marking a function as unsupported will replace all calls to this function by a call to `panic!`, which will cause any test of verification reaching that path to fail. This is useful because this prevent pulling all the function reachable from the unsupported functions in the translated code, and therefore makes it easy to remove whole subsystems from the Rust.

For instance, on the Arm model the instruction to read MSRs can read memory in some circumstances, therefore pulling the whole virtual memory subsystem. By marking the memory read function as unsupported, we can compile the MSR instruction but will panic in the specific cases that would trigger a memory read.