### PR TITLE
Update compiler to add support for the Flashpoint extension

### DIFF
--- a/sail_rust_backend/rust_backend.ml
+++ b/sail_rust_backend/rust_backend.ml
@@ -406,7 +406,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
        | Ord_aux (Ord_dec, _) -> RsTodo "E_for_dec")
     | E_for (_, _, _, _, _, _) -> RsTodo "E_for"
     | E_vector exp_list -> process_vector ctx exp_list typ
-    | E_vector_access (exp1, exp2) -> RsTodo "E_vector_access"
+    | E_vector_access (exp1, exp2) -> RsIndex (process_exp ctx exp1, process_exp ctx exp2)
     | E_vector_subrange (exp1, exp2, exp3) -> RsTodo "E_vector_subrange"
     | E_vector_update (exp1, exp2, exp3) -> RsTodo "E_vector_update"
     | E_vector_update_subrange (exp1, exp2, exp3, exp4) -> RsTodo "E_update_subrange"

--- a/sail_rust_backend/rust_backend.ml
+++ b/sail_rust_backend/rust_backend.ml
@@ -274,7 +274,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
       (match size1, size2 with
        (* 64 bits overflow, switch to 128 bits *)
        | Some n, Some m when Int64.mul n m >= 64L ->
-         RsBinop (RsAs (exp1, nat_typ), RsBinopMult, RsAs (exp2, nat_typ))
+         RsBinop (RsAs (exp1, int_typ), RsBinopMult, RsAs (exp2, int_typ))
        | _ -> RsBinop (exp1, RsBinopMult, exp2))
     | _ ->
       Reporting.simple_warn

--- a/sail_rust_backend/rust_transform.ml
+++ b/sail_rust_backend/rust_transform.ml
@@ -1469,7 +1469,7 @@ let transform_basic_types_exp (ctx : context) (exp : rs_exp) : rs_exp =
     let patch_arg (exp, typ) =
       match typ with
       (* Conversion between integer types is not automatic, therefore we need to insert some casts *)
-      | RsTypId "nat" -> RsAs (exp, RsTypId "u128")
+      | RsTypId "nat" -> RsAs (exp, nat_typ)
       | _ -> exp
     in
     let args =


### PR DESCRIPTION
This PR adds compiler support for the Flashpoint RISC-V extension (flashpoint is a research project). The RISC-V model with the flashpoint ISA extension will be kept on a separate branch, and not merged into mail (unless it becomes part of the official ISA eventually).