### PR TITLE
Extend softcore-rs to support the full Miralis codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0]
+
+### RISC-V 64
+
+- Add support for `flush_TLB`
+- Add support for `csr_name_map_backwards_matches`
+- Add support for `handle_illegal`
+- [**breaking**] Handle trap after execute
+
+### Compiler
+
+- Add support for expression in for loop ranges
+- Add support for `vector_length`
+- Add support for vector access
+
 ## [0.5.0]
 
 ### Armv9-A

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,18 +60,18 @@ dependencies = [
 
 [[package]]
 name = "softcore-armv9a"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "softcore-prelude",
 ]
 
 [[package]]
 name = "softcore-prelude"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "softcore-rv64"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "softcore-prelude",
 ]

--- a/armv9a/Cargo.toml
+++ b/armv9a/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softcore-armv9a"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Charly Castes"]
 license = "MIT OR Apache-2.0"
@@ -11,4 +11,4 @@ categories = ["emulators", "development-tools::testing"]
 readme = "readme.md"
 
 [dependencies]
-softcore-prelude = { version = "0.5.0", path = "../prelude" }
+softcore-prelude = { version = "0.6.0", path = "../prelude" }

--- a/prelude/Cargo.toml
+++ b/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softcore-prelude"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Charly Castes", "François Costa"]
 license = "MIT OR Apache-2.0"

--- a/prelude/src/lib.rs
+++ b/prelude/src/lib.rs
@@ -82,7 +82,10 @@ pub fn truncate(v: BitVector<64>, size: i128) -> BitVector<64> {
     v
 }
 
-pub fn sail_sign_extend<const M: i128, const N: i128>(input: BitVector<M>, n: i128) -> BitVector<N> {
+pub fn sail_sign_extend<const M: i128, const N: i128>(
+    input: BitVector<M>,
+    n: i128,
+) -> BitVector<N> {
     assert!(n == N, "Mismatch `sail_sign_extend` size");
     assert!(N >= M, "Cannot sign extend to smaller size");
     assert!(N <= 64, "Maximum supported size is 64 for now");
@@ -141,8 +144,15 @@ pub fn hex_bits_12_forwards(_reg: BitVector<12>) -> ! {
     todo!("Implement this function")
 }
 
-pub fn hex_bits_12_backwards(bits: &'static str) -> BitVector<12> {
+pub fn hex_bits_12_backwards(bits: &str) -> BitVector<12> {
     hex_bits(bits)
+}
+
+pub fn hex_bits_12_backwards_matches(bits: &str) -> bool {
+    match bits.parse::<u64>() {
+        Ok(n) => n < (1 << 12),
+        Err(_) => false,
+    }
 }
 
 pub fn subrange_bits<const IN: i128, const OUT: i128>(

--- a/prelude/src/lib.rs
+++ b/prelude/src/lib.rs
@@ -132,12 +132,17 @@ pub fn cancel_reservation(_unit: ()) {
     // In the future, extend this function
 }
 
+fn hex_bits<const N: i128>(bits: &str) -> BitVector<N> {
+    let parsed = bits.parse::<u64>().expect("Could not parse hex bits");
+    bv(parsed)
+}
+
 pub fn hex_bits_12_forwards(_reg: BitVector<12>) -> ! {
     todo!("Implement this function")
 }
 
-pub fn hex_bits_12_backwards(_: &'static str) -> BitVector<12> {
-    todo!("Implement this function")
+pub fn hex_bits_12_backwards(bits: &'static str) -> BitVector<12> {
+    hex_bits(bits)
 }
 
 pub fn subrange_bits<const IN: i128, const OUT: i128>(

--- a/rv64/Cargo.toml
+++ b/rv64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "softcore-rv64"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Charly Castes", "François Costa"]
 license = "MIT OR Apache-2.0"
@@ -11,4 +11,4 @@ categories = ["emulators", "development-tools::testing"]
 readme = "readme.md"
 
 [dependencies]
-softcore-prelude = { version = "0.5.0", path = "../prelude" }
+softcore-prelude = { version = "0.6.0", path = "../prelude" }

--- a/rv64/src/arch_prelude.rs
+++ b/rv64/src/arch_prelude.rs
@@ -12,7 +12,7 @@ pub const fn rem_round_zero(n: i128, m: i128) -> i128 {
     n % m
 }
 
-pub fn sign_extend<const M: i128, const N: i128>( n: i128, input: BitVector<M>) -> BitVector<N> {
+pub fn sign_extend<const M: i128, const N: i128>(n: i128, input: BitVector<M>) -> BitVector<N> {
     sail_sign_extend(input, n)
 }
 
@@ -99,11 +99,17 @@ mod tests {
 
         // Test shift >= N for positive number - should become all zeros
         assert_eq!(shift_right_arith(bv::<8>(0b01110111), 8).bits(), 0b00000000);
-        assert_eq!(shift_right_arith(bv::<8>(0b01110111), 10).bits(), 0b00000000);
+        assert_eq!(
+            shift_right_arith(bv::<8>(0b01110111), 10).bits(),
+            0b00000000
+        );
 
         // Test shift >= N for negative number - should become all ones
         assert_eq!(shift_right_arith(bv::<8>(0b10110111), 8).bits(), 0b11111111);
-        assert_eq!(shift_right_arith(bv::<8>(0b10110111), 10).bits(), 0b11111111);
+        assert_eq!(
+            shift_right_arith(bv::<8>(0b10110111), 10).bits(),
+            0b11111111
+        );
 
         // Test with different bit widths - 16-bit
         assert_eq!(
@@ -120,9 +126,18 @@ mod tests {
         );
 
         // Test with 32-bit values
-        assert_eq!(shift_right_arith(bv::<32>(0x7FFFFFFF), 16).bits(), 0x00007FFF);
-        assert_eq!(shift_right_arith(bv::<32>(0x80000000), 16).bits(), 0xFFFF8000);
-        assert_eq!(shift_right_arith(bv::<32>(0xFFFFFFFF), 16).bits(), 0xFFFFFFFF);
+        assert_eq!(
+            shift_right_arith(bv::<32>(0x7FFFFFFF), 16).bits(),
+            0x00007FFF
+        );
+        assert_eq!(
+            shift_right_arith(bv::<32>(0x80000000), 16).bits(),
+            0xFFFF8000
+        );
+        assert_eq!(
+            shift_right_arith(bv::<32>(0xFFFFFFFF), 16).bits(),
+            0xFFFFFFFF
+        );
 
         // Test with 64-bit values (edge case for mask calculation)
         assert_eq!(
@@ -144,7 +159,13 @@ mod tests {
         assert_eq!(shift_right_arith(bv::<4>(0b1000), 2).bits(), 0b1110);
 
         // Test negative shift - should return original value
-        assert_eq!(shift_right_arith(bv::<8>(0b10110111), -1).bits(), 0b10110111);
-        assert_eq!(shift_right_arith(bv::<8>(0b01110111), -5).bits(), 0b01110111);
+        assert_eq!(
+            shift_right_arith(bv::<8>(0b10110111), -1).bits(),
+            0b10110111
+        );
+        assert_eq!(
+            shift_right_arith(bv::<8>(0b01110111), -5).bits(),
+            0b01110111
+        );
     }
 }

--- a/rv64/src/config.rs
+++ b/rv64/src/config.rs
@@ -72,6 +72,7 @@ pub const MINIMAL: raw::Config = raw::Config {
         Zvksh: raw::ConfigZvksh { supported: false },
     },
     base: raw::ConfigBase {
+        mtval_has_illegal_instruction_bits: false,
         writable_fiom: false,
         writable_hpm_counters: BitVector::new(0),
         writable_misa: false,
@@ -152,6 +153,7 @@ pub const U74: raw::Config = raw::Config {
         Zvksh: raw::ConfigZvksh { supported: false },
     },
     base: raw::ConfigBase {
+        mtval_has_illegal_instruction_bits: true,
         writable_fiom: true,
         writable_hpm_counters: BitVector::new(0), // TODO: check on a board
         writable_misa: false,

--- a/sail_rust_backend/arch/rv64.ml
+++ b/sail_rust_backend/arch/rv64.ml
@@ -32,6 +32,7 @@ let call_set =
     ; "exceptionType_to_bits"
     ; "dispatchInterrupt"
     ; "handle_interrupt"
+    ; "handle_illegal"
     ; (* CSRs *)
       "read_CSR"
     ; "write_CSR"
@@ -79,7 +80,6 @@ let external_func : SSet.t =
       ; "bitvector_concat"
       ; "print_platform"
       ; "cancel_reservation"
-      ; "plat_mtval_has_illegal_inst_bits"
       ; "truncate"
       ; "subrange_bits"
       ; "internal_error"

--- a/sail_rust_backend/arch/rv64.ml
+++ b/sail_rust_backend/arch/rv64.ml
@@ -15,6 +15,8 @@ let call_set =
     ; "HFENCE_GVMA"
     ; (* Decoder *)
       "encdec_backwards"
+    ; (* CSR names validity check *)
+      "csr_name_map_backwards_matches"
     ; (* Registers *)
       "rX"
     ; "wX"
@@ -39,7 +41,13 @@ let call_set =
     ]
 ;;
 
-let overwritten_func : SSet.t = SSet.of_list [ "shift_right_arith" ]
+let overwritten_func : SSet.t =
+  SSet.of_list
+    [ "shift_right_arith"
+      (* Necessary until https://github.com/rems-project/sail/issues/1596 is fixed: *)
+    ; "hex_bits_12_backwards_matches"
+    ]
+;;
 
 let external_func : SSet.t =
   let externals =

--- a/sail_rust_backend/arch/rv64.ml
+++ b/sail_rust_backend/arch/rv64.ml
@@ -15,6 +15,7 @@ let call_set =
     ; "HFENCE_GVMA"
     ; (* Decoder *)
       "encdec_backwards"
+    ; "encdec_forwards"
     ; (* CSR names validity check *)
       "csr_name_map_backwards_matches"
     ; (* Registers *)

--- a/tests/csr/arch.rs
+++ b/tests/csr/arch.rs
@@ -112,6 +112,17 @@ pub fn wX(core_ctx: &mut Core, r: BitVector<5>, v: BitVector<64>) {
     }
 }
 
+/// bool_bits_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn bool_bits_forwards(arg_hashtag_: bool) -> BitVector<1> {
+    match arg_hashtag_ {
+        true => {BitVector::<1>::new(0b1)}
+        false => {BitVector::<1>::new(0b0)}
+        _ => {panic!("Unreachable code")}
+    }
+}
+
 /// bool_bits_backwards
 /// 
 /// Generated from the Sail sources.
@@ -183,6 +194,18 @@ pub enum ast {
     CSR((BitVector<12>, regidx, regidx, bool, csrop))
 }
 
+/// encdec_csrop_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn encdec_csrop_forwards(arg_hashtag_: csrop) -> BitVector<2> {
+    match arg_hashtag_ {
+        csrop::CSRRW => {BitVector::<2>::new(0b01)}
+        csrop::CSRRS => {BitVector::<2>::new(0b10)}
+        csrop::CSRRC => {BitVector::<2>::new(0b11)}
+        _ => {panic!("Unreachable code")}
+    }
+}
+
 /// encdec_csrop_backwards
 /// 
 /// Generated from the Sail sources.
@@ -222,6 +245,17 @@ pub fn csrAccess(csr: BitVector<12>) -> BitVector<2> {
 /// Generated from the Sail sources at `tests/csr/arch.sail` L136.
 pub fn csrPriv(csr: BitVector<12>) -> BitVector<2> {
     csr.subrange::<8, 10, 2>()
+}
+
+/// encdec_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn encdec_forwards(arg_hashtag_: ast) -> BitVector<32> {
+    match arg_hashtag_ {
+        ast::ITYPE((imm, rs1, rd, iop::RISCV_ADDI)) => {bitvector_concat::<12, 20, 32>((imm as BitVector<12>), bitvector_concat::<5, 15, 20>((rs1 as regidx), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>((rd as regidx), BitVector::<7>::new(0b0010011)))))}
+        ast::CSR((csr, rs1, rd, is_imm, op)) => {bitvector_concat::<12, 20, 32>((csr as BitVector<12>), bitvector_concat::<5, 15, 20>((rs1 as BitVector<5>), bitvector_concat::<1, 14, 15>(bool_bits_forwards(is_imm), bitvector_concat::<2, 12, 14>(encdec_csrop_forwards(op), bitvector_concat::<5, 7, 12>((rd as BitVector<5>), BitVector::<7>::new(0b1110011))))))}
+        _ => {panic!("Unreachable code")}
+    }
 }
 
 /// encdec_backwards

--- a/tests/decoder/arch.rs
+++ b/tests/decoder/arch.rs
@@ -51,6 +51,17 @@ pub type cregidx = BitVector<3>;
 
 pub type csreg = BitVector<12>;
 
+/// bool_bits_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn bool_bits_forwards(arg_hashtag_: bool) -> BitVector<1> {
+    match arg_hashtag_ {
+        true => {BitVector::<1>::new(0b1)}
+        false => {BitVector::<1>::new(0b0)}
+        _ => {panic!("Unreachable code")}
+    }
+}
+
 /// bool_bits_backwards
 /// 
 /// Generated from the Sail sources.
@@ -120,6 +131,18 @@ pub enum ast {
     HFENCE_GVMA((BitVector<5>, BitVector<5>))
 }
 
+/// encdec_csrop_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn encdec_csrop_forwards(arg_hashtag_: csrop) -> BitVector<2> {
+    match arg_hashtag_ {
+        csrop::CSRRW => {BitVector::<2>::new(0b01)}
+        csrop::CSRRS => {BitVector::<2>::new(0b10)}
+        csrop::CSRRC => {BitVector::<2>::new(0b11)}
+        _ => {panic!("Unreachable code")}
+    }
+}
+
 /// encdec_csrop_backwards
 /// 
 /// Generated from the Sail sources.
@@ -146,6 +169,22 @@ pub fn encdec_csrop_backwards_matches(arg_hashtag_: BitVector<2>) -> bool {
 }
 
 pub type csrRW = BitVector<2>;
+
+/// encdec_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn encdec_forwards(arg_hashtag_: ast) -> BitVector<32> {
+    match arg_hashtag_ {
+        ast::CSR((csr, rs1, rd, is_imm, op)) => {bitvector_concat::<12, 20, 32>((csr as BitVector<12>), bitvector_concat::<5, 15, 20>((rs1 as BitVector<5>), bitvector_concat::<1, 14, 15>(bool_bits_forwards(is_imm), bitvector_concat::<2, 12, 14>(encdec_csrop_forwards(op), bitvector_concat::<5, 7, 12>((rd as BitVector<5>), BitVector::<7>::new(0b1110011))))))}
+        ast::MRET(()) => {bitvector_concat::<7, 25, 32>(BitVector::<7>::new(0b0011000), bitvector_concat::<5, 20, 25>(BitVector::<5>::new(0b00010), bitvector_concat::<5, 15, 20>(BitVector::<5>::new(0b00000), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>(BitVector::<5>::new(0b00000), BitVector::<7>::new(0b1110011))))))}
+        ast::SRET(()) => {bitvector_concat::<7, 25, 32>(BitVector::<7>::new(0b0001000), bitvector_concat::<5, 20, 25>(BitVector::<5>::new(0b00010), bitvector_concat::<5, 15, 20>(BitVector::<5>::new(0b00000), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>(BitVector::<5>::new(0b00000), BitVector::<7>::new(0b1110011))))))}
+        ast::WFI(()) => {bitvector_concat::<12, 20, 32>(BitVector::<12>::new(0b000100000101), bitvector_concat::<5, 15, 20>(BitVector::<5>::new(0b00000), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>(BitVector::<5>::new(0b00000), BitVector::<7>::new(0b1110011)))))}
+        ast::SFENCE_VMA((rs1, rs2)) => {bitvector_concat::<7, 25, 32>(BitVector::<7>::new(0b0001001), bitvector_concat::<5, 20, 25>((rs2 as BitVector<5>), bitvector_concat::<5, 15, 20>((rs1 as BitVector<5>), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>(BitVector::<5>::new(0b00000), BitVector::<7>::new(0b1110011))))))}
+        ast::HFENCE_VVMA((rs1, rs2)) => {bitvector_concat::<7, 25, 32>(BitVector::<7>::new(0b0010001), bitvector_concat::<5, 20, 25>((rs2 as BitVector<5>), bitvector_concat::<5, 15, 20>((rs1 as BitVector<5>), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>(BitVector::<5>::new(0b00000), BitVector::<7>::new(0b1110011))))))}
+        ast::HFENCE_GVMA((rs1, rs2)) => {bitvector_concat::<7, 25, 32>(BitVector::<7>::new(0b0110001), bitvector_concat::<5, 20, 25>((rs2 as BitVector<5>), bitvector_concat::<5, 15, 20>((rs1 as BitVector<5>), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>(BitVector::<5>::new(0b00000), BitVector::<7>::new(0b1110011))))))}
+        _ => {panic!("Unreachable code")}
+    }
+}
 
 /// encdec_backwards
 /// 

--- a/tests/mret/arch.rs
+++ b/tests/mret/arch.rs
@@ -221,6 +221,16 @@ pub enum ast {
     MRET(())
 }
 
+/// encdec_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn encdec_forwards(arg_hashtag_: ast) -> BitVector<32> {
+    match arg_hashtag_ {
+        ast::MRET(()) => {bitvector_concat::<7, 25, 32>(BitVector::<7>::new(0b0011000), bitvector_concat::<5, 20, 25>(BitVector::<5>::new(0b00010), bitvector_concat::<5, 15, 20>(BitVector::<5>::new(0b00000), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>(BitVector::<5>::new(0b00000), BitVector::<7>::new(0b1110011))))))}
+        _ => {panic!("Unreachable code")}
+    }
+}
+
 /// encdec_backwards
 /// 
 /// Generated from the Sail sources.

--- a/tests/trap/arch.rs
+++ b/tests/trap/arch.rs
@@ -258,6 +258,17 @@ pub fn wX(core_ctx: &mut Core, r: BitVector<5>, v: BitVector<64>) {
     }
 }
 
+/// bool_bits_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn bool_bits_forwards(arg_hashtag_: bool) -> BitVector<1> {
+    match arg_hashtag_ {
+        true => {BitVector::<1>::new(0b1)}
+        false => {BitVector::<1>::new(0b0)}
+        _ => {panic!("Unreachable code")}
+    }
+}
+
 /// bool_bits_backwards
 /// 
 /// Generated from the Sail sources.
@@ -625,6 +636,18 @@ pub enum ast {
     CSR((BitVector<12>, regidx, regidx, bool, csrop))
 }
 
+/// encdec_csrop_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn encdec_csrop_forwards(arg_hashtag_: csrop) -> BitVector<2> {
+    match arg_hashtag_ {
+        csrop::CSRRW => {BitVector::<2>::new(0b01)}
+        csrop::CSRRS => {BitVector::<2>::new(0b10)}
+        csrop::CSRRC => {BitVector::<2>::new(0b11)}
+        _ => {panic!("Unreachable code")}
+    }
+}
+
 /// encdec_csrop_backwards
 /// 
 /// Generated from the Sail sources.
@@ -664,6 +687,17 @@ pub fn csrAccess(csr: BitVector<12>) -> BitVector<2> {
 /// Generated from the Sail sources at `tests/trap/arch.sail` L437.
 pub fn csrPriv(csr: BitVector<12>) -> BitVector<2> {
     csr.subrange::<8, 10, 2>()
+}
+
+/// encdec_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn encdec_forwards(arg_hashtag_: ast) -> BitVector<32> {
+    match arg_hashtag_ {
+        ast::ITYPE((imm, rs1, rd, iop::RISCV_ADDI)) => {bitvector_concat::<12, 20, 32>((imm as BitVector<12>), bitvector_concat::<5, 15, 20>((rs1 as regidx), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>((rd as regidx), BitVector::<7>::new(0b0010011)))))}
+        ast::CSR((csr, rs1, rd, is_imm, op)) => {bitvector_concat::<12, 20, 32>((csr as BitVector<12>), bitvector_concat::<5, 15, 20>((rs1 as BitVector<5>), bitvector_concat::<1, 14, 15>(bool_bits_forwards(is_imm), bitvector_concat::<2, 12, 14>(encdec_csrop_forwards(op), bitvector_concat::<5, 7, 12>((rd as BitVector<5>), BitVector::<7>::new(0b1110011))))))}
+        _ => {panic!("Unreachable code")}
+    }
 }
 
 /// encdec_backwards

--- a/tests/wfi/arch.rs
+++ b/tests/wfi/arch.rs
@@ -119,6 +119,16 @@ pub enum ast {
     WFI(())
 }
 
+/// encdec_forwards
+/// 
+/// Generated from the Sail sources.
+pub fn encdec_forwards(arg_hashtag_: ast) -> BitVector<32> {
+    match arg_hashtag_ {
+        ast::WFI(()) => {bitvector_concat::<12, 20, 32>(BitVector::<12>::new(0b000100000101), bitvector_concat::<5, 15, 20>(BitVector::<5>::new(0b00000), bitvector_concat::<3, 12, 15>(BitVector::<3>::new(0b000), bitvector_concat::<5, 7, 12>(BitVector::<5>::new(0b00000), BitVector::<7>::new(0b1110011)))))}
+        _ => {panic!("Unreachable code")}
+    }
+}
+
 /// encdec_backwards
 /// 
 /// Generated from the Sail sources.


### PR DESCRIPTION
With those changes we can finally run all of the assembly snippets from the [Miralis](https://github.com/CharlyCst/miralis) code base using softcore-asm.
In order to merge the Miralis version relying on softcore-asm we will publish those changes as v0.6.0.