### PR TITLE
Remove warning for unused variables when using dune build

### DIFF
--- a/sail_rust_backend/call_set.ml
+++ b/sail_rust_backend/call_set.ml
@@ -25,7 +25,7 @@ let add_config (config : string) (t : typ) (ctx : sail_ctx) : sail_ctx =
 ;;
 
 let ctx_union (ctx1 : sail_ctx) (ctx2 : sail_ctx) : sail_ctx =
-  let choose_typ (cfg : string) (a : typ) (b : typ) : typ option =
+  let choose_typ (_ : string) (a : typ) (b : typ) : typ option =
     let ret = Some a in
     if a <> b
     then (
@@ -43,12 +43,12 @@ let ctx_union (ctx1 : sail_ctx) (ctx2 : sail_ctx) : sail_ctx =
 ;;
 
 let rec exp_call_set (texp : tannot exp) (arch : arch_t) (ctx : sail_ctx) : sail_ctx =
-  let (E_aux (exp, aux)) = texp in
+  let (E_aux (exp, _)) = texp in
   match exp with
   | E_block exp_list -> List.fold_left (fold_set arch) ctx exp_list
-  | E_id id -> ctx
-  | E_lit lit -> ctx
-  | E_typ (typ, exp) -> exp_call_set exp arch ctx
+  | E_id _ -> ctx
+  | E_lit _ -> ctx
+  | E_typ (_, exp) -> exp_call_set exp arch ctx
   | E_app (id, exp_list) ->
     let id = string_of_id id in
     if SSet.mem id arch.unsupported_func || SSet.mem id arch.overwritten_func
@@ -56,7 +56,7 @@ let rec exp_call_set (texp : tannot exp) (arch : arch_t) (ctx : sail_ctx) : sail
     else (
       let ctx = add_fn id ctx in
       List.fold_left (fold_set arch) ctx exp_list)
-  | E_app_infix (exp1, id, exp2) ->
+  | E_app_infix (exp1, _, exp2) ->
     ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
   | E_tuple exp_list -> List.fold_left (fold_set arch) ctx exp_list
   | E_if (exp1, exp2, exp3) ->
@@ -64,15 +64,16 @@ let rec exp_call_set (texp : tannot exp) (arch : arch_t) (ctx : sail_ctx) : sail
     let s = exp_call_set exp2 arch s in
     let s = exp_call_set exp3 arch s in
     s
-  | E_loop (loop, measure, exp1, exp2) ->
+  | E_loop (_, _, exp1, exp2) ->
     ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
-  | E_for (id, exp1, exp2, exp3, order, exp4) ->
+  | E_for (_, exp1, exp2, exp3, _, exp4) ->
     let s = ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx) in
     let s = ctx_union (exp_call_set exp3 arch s) s in
     ctx_union (exp_call_set exp4 arch s) s
   | E_vector exp_list -> List.fold_left (fold_set arch) ctx exp_list
   | E_vector_access (exp1, exp2) ->
     ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
+  (* NOTES(Gurvan): Shouldn't the following exp also be added to the context ? *)
   | E_vector_subrange (exp1, exp2, exp3) -> ctx
   | E_vector_update (exp1, exp2, exp3) -> ctx
   | E_vector_update_subrange (exp1, exp2, exp3, exp4) -> ctx
@@ -81,44 +82,44 @@ let rec exp_call_set (texp : tannot exp) (arch : arch_t) (ctx : sail_ctx) : sail
   | E_cons (exp1, exp2) -> ctx
   | E_struct fexp_list -> ctx
   | E_struct_update (exp, fexp_list) -> ctx
-  | E_field (exp, id) -> exp_call_set exp arch ctx
+  | E_field (exp, _) -> exp_call_set exp arch ctx
   | E_match (exp, pexp_list) ->
     let s = exp_call_set exp arch ctx in
     let fold_set_pexp s pexp = ctx_union s (pexp_call_set pexp arch s) in
     List.fold_left fold_set_pexp s pexp_list
-  | E_let (LB_aux (LB_val (let_var, let_exp), _), exp) ->
+  | E_let (LB_aux (LB_val (_, let_exp), _), exp) ->
     let s = exp_call_set let_exp arch ctx in
     exp_call_set exp arch s
-  | E_var (lexp, exp1, exp2) ->
+  | E_var (_, exp1, exp2) ->
     ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
-  | E_assign (lexp, exp) -> exp_call_set exp arch ctx
-  | E_sizeof nexp -> ctx
+  | E_assign (_, exp) -> exp_call_set exp arch ctx
+  | E_sizeof _ -> ctx
   | E_return exp -> exp_call_set exp arch ctx
   | E_exit exp -> exp_call_set exp arch ctx
-  | E_ref id -> ctx
-  | E_throw exp -> ctx
-  | E_try (exp, pexp_list) -> ctx
+  | E_ref _ -> ctx
+  | E_throw _ -> ctx
+  | E_try (_, _) -> ctx
   | E_assert (exp1, exp2) ->
     ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
-  | E_internal_plet (pat, exp1, exp2) -> ctx
-  | E_internal_return exp -> ctx
-  | E_internal_value value -> ctx
-  | E_internal_assume (n_constraint, exp) -> ctx
-  | E_constraint n_constraint -> ctx
+  | E_internal_plet _ -> ctx
+  | E_internal_return _ -> ctx
+  | E_internal_value _ -> ctx
+  | E_internal_assume _ -> ctx
+  | E_constraint _ -> ctx
   | E_config cfgs ->
     let typ = typ_of texp in
     let cfg = String.concat "." cfgs in
     add_config cfg typ ctx
 
-and pexp_call_set (Pat_aux (pexp, annot)) (arch : arch_t) (ctx : sail_ctx) : sail_ctx =
+and pexp_call_set (Pat_aux (pexp, _)) (arch : arch_t) (ctx : sail_ctx) : sail_ctx =
   match pexp with
   | Pat_exp (P_aux (P_id id, _), _)
   | Pat_when (P_aux (P_id id, _), _, _)
   | Pat_exp (P_aux (P_app (id, _), _), _)
   | Pat_when (P_aux (P_app (id, _), _), _, _)
     when SSet.mem (string_of_id id) arch.unsupported_match -> ctx
-  | Pat_exp (pat, exp) -> exp_call_set exp arch ctx
-  | Pat_when (pat, exp1, exp2) ->
+  | Pat_exp (_, exp) -> exp_call_set exp arch ctx
+  | Pat_when (_, exp1, exp2) ->
     ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
 
 and fold_set (arch : arch_t) (ctx : sail_ctx) exp =
@@ -133,12 +134,12 @@ let pat_app_name (P_aux (pat_aux, _)) =
 ;;
 
 let func_call_set
-      (FCL_aux (FCL_funcl (id, pexp), annot) : tannot funcl)
+      (FCL_aux (FCL_funcl (id, pexp), _) : tannot funcl)
       (arch : arch_t)
       (ctx : sail_ctx)
   : sail_ctx
   =
-  let pexp, annot =
+  let pexp, _ =
     match pexp with
     | Pat_aux (pexp, annot) -> pexp, annot
   in
@@ -146,8 +147,8 @@ let func_call_set
   if SSet.mem name ctx.call_set
   then (
     match pexp with
-    | Pat_exp (pat, exp) -> exp_call_set exp arch ctx
-    | Pat_when (pat1, exp, pat2) -> exp_call_set exp arch ctx)
+    | Pat_exp (_, exp) -> exp_call_set exp arch ctx
+    | Pat_when (_, exp, _) -> exp_call_set exp arch ctx)
   else (
     match pexp with
     | Pat_exp (pat, exp) ->
@@ -165,7 +166,7 @@ let rec funcl_call_set (funcl : tannot funcl list) (arch : arch_t) (ctx : sail_c
 ;;
 
 let fundef_call_set
-      (FD_function (rec_opt, tannot_opt, funcl) : tannot fundef_aux)
+      (FD_function (_, _, funcl) : tannot fundef_aux)
       (arch : arch_t)
       (ctx : sail_ctx)
   : sail_ctx
@@ -179,13 +180,13 @@ let register_call_set (DEC_reg (_, _, exp)) (arch : arch_t) (ctx : sail_ctx) : s
   | None -> ctx
 ;;
 
-let node_call_set (DEF_aux (def, annot)) (arch : arch_t) (ctx : sail_ctx) : sail_ctx =
+let node_call_set (DEF_aux (def, _)) (arch : arch_t) (ctx : sail_ctx) : sail_ctx =
   match def with
-  | DEF_register (DEC_aux (dec_spec, annot)) -> register_call_set dec_spec arch ctx
-  | DEF_scattered (SD_aux (scattered, annot)) -> ctx
-  | DEF_fundef (FD_aux (fundef, annot)) -> fundef_call_set fundef arch ctx
+  | DEF_register (DEC_aux (dec_spec, _)) -> register_call_set dec_spec arch ctx
+  | DEF_scattered (SD_aux (_, _)) -> ctx
+  | DEF_fundef (FD_aux (fundef, _)) -> fundef_call_set fundef arch ctx
   | DEF_impl funcl -> func_call_set funcl arch ctx
-  | DEF_let (LB_aux (LB_val (pat, exp), aux)) -> exp_call_set exp arch ctx
+  | DEF_let (LB_aux (LB_val (_, exp), _)) -> exp_call_set exp arch ctx
   | _ -> ctx
 ;;
 
@@ -206,7 +207,7 @@ let rec get_call_set_rec (arch : arch_t) (ast : (tannot, env) ast) (ctx : sail_c
   else get_call_set_rec arch ast new_ctx
 ;;
 
-let rec get_call_set (arch : arch_t) (ast : (tannot, env) ast) : sail_ctx =
+let get_call_set (arch : arch_t) (ast : (tannot, env) ast) : sail_ctx =
   let call_set = arch.call_set in
   let sail_ctx = { call_set; config_map = SMap.empty } in
   get_call_set_rec arch ast sail_ctx

--- a/sail_rust_backend/call_set.ml
+++ b/sail_rust_backend/call_set.ml
@@ -21,25 +21,18 @@ let add_fn (fn : string) (ctx : sail_ctx) : sail_ctx =
 ;;
 
 let add_config (config : string) (t : typ) (ctx : sail_ctx) : sail_ctx =
-  { ctx with config_map = SMap.add config t ctx.config_map }
-;;
-
-let ctx_union (ctx1 : sail_ctx) (ctx2 : sail_ctx) : sail_ctx =
-  let choose_typ (_ : string) (a : typ) (b : typ) : typ option =
-    let ret = Some a in
-    if a <> b
-    then (
-      Reporting.simple_warn
-        (Printf.sprintf
-           "Config used with different types: %s and %s"
-           (string_of_typ a)
-           (string_of_typ b));
-      ret)
-    else ret
-  in
-  { call_set = SSet.union ctx1.call_set ctx2.call_set
-  ; config_map = SMap.union choose_typ ctx1.config_map ctx2.config_map
-  }
+  let res = { ctx with config_map = SMap.add config t ctx.config_map } in
+  (match SMap.find_opt config ctx.config_map with
+   | Some t' ->
+     if t <> t'
+     then
+       Reporting.simple_warn
+         (Printf.sprintf
+            "Config used with different types: %s and %s"
+            (string_of_typ t)
+            (string_of_typ t'))
+   | None -> ());
+  res
 ;;
 
 let rec exp_call_set (texp : tannot exp) (arch : arch_t) (ctx : sail_ctx) : sail_ctx =
@@ -56,42 +49,47 @@ let rec exp_call_set (texp : tannot exp) (arch : arch_t) (ctx : sail_ctx) : sail
     else (
       let ctx = add_fn id ctx in
       List.fold_left (fold_set arch) ctx exp_list)
-  | E_app_infix (exp1, _, exp2) ->
-    ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
+  | E_app_infix (exp1, _, exp2) -> ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch
   | E_tuple exp_list -> List.fold_left (fold_set arch) ctx exp_list
   | E_if (exp1, exp2, exp3) ->
-    let s = exp_call_set exp1 arch ctx in
-    let s = exp_call_set exp2 arch s in
-    let s = exp_call_set exp3 arch s in
-    s
-  | E_loop (_, _, exp1, exp2) ->
-    ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
+    ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch |> exp_call_set exp3 arch
+  | E_loop (_, _, exp1, exp2) -> ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch
   | E_for (_, exp1, exp2, exp3, _, exp4) ->
-    let s = ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx) in
-    let s = ctx_union (exp_call_set exp3 arch s) s in
-    ctx_union (exp_call_set exp4 arch s) s
+    ctx
+    |> exp_call_set exp1 arch
+    |> exp_call_set exp2 arch
+    |> exp_call_set exp3 arch
+    |> exp_call_set exp4 arch
   | E_vector exp_list -> List.fold_left (fold_set arch) ctx exp_list
   | E_vector_access (exp1, exp2) ->
-    ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
-  (* NOTES(Gurvan): Shouldn't the following exp also be added to the context ? *)
-  | E_vector_subrange (exp1, exp2, exp3) -> ctx
-  | E_vector_update (exp1, exp2, exp3) -> ctx
-  | E_vector_update_subrange (exp1, exp2, exp3, exp4) -> ctx
-  | E_vector_append (exp1, exp2) -> ctx
+    ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch
+  | E_vector_subrange (exp1, exp2, exp3) ->
+    ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch |> exp_call_set exp3 arch
+  | E_vector_update (exp1, exp2, exp3) ->
+    ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch |> exp_call_set exp3 arch
+  | E_vector_update_subrange (exp1, exp2, exp3, exp4) ->
+    ctx
+    |> exp_call_set exp1 arch
+    |> exp_call_set exp2 arch
+    |> exp_call_set exp3 arch
+    |> exp_call_set exp4 arch
+  | E_vector_append (exp1, exp2) ->
+    ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch
   | E_list exp_list -> List.fold_left (fold_set arch) ctx exp_list
-  | E_cons (exp1, exp2) -> ctx
-  | E_struct fexp_list -> ctx
-  | E_struct_update (exp, fexp_list) -> ctx
+  | E_cons (exp1, exp2) -> ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch
+  | E_struct fexp_list -> List.fold_left (fun c f -> fexp_call_set f arch c) ctx fexp_list
+  | E_struct_update (exp, fexp_list) ->
+    List.fold_left (fun c f -> fexp_call_set f arch c) ctx fexp_list
+    |> exp_call_set exp arch
   | E_field (exp, _) -> exp_call_set exp arch ctx
   | E_match (exp, pexp_list) ->
     let s = exp_call_set exp arch ctx in
-    let fold_set_pexp s pexp = ctx_union s (pexp_call_set pexp arch s) in
+    let fold_set_pexp s pexp = pexp_call_set pexp arch s in
     List.fold_left fold_set_pexp s pexp_list
   | E_let (LB_aux (LB_val (_, let_exp), _), exp) ->
     let s = exp_call_set let_exp arch ctx in
     exp_call_set exp arch s
-  | E_var (_, exp1, exp2) ->
-    ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
+  | E_var (_, exp1, exp2) -> ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch
   | E_assign (_, exp) -> exp_call_set exp arch ctx
   | E_sizeof _ -> ctx
   | E_return exp -> exp_call_set exp arch ctx
@@ -99,8 +97,7 @@ let rec exp_call_set (texp : tannot exp) (arch : arch_t) (ctx : sail_ctx) : sail
   | E_ref _ -> ctx
   | E_throw _ -> ctx
   | E_try (_, _) -> ctx
-  | E_assert (exp1, exp2) ->
-    ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
+  | E_assert (exp1, exp2) -> ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch
   | E_internal_plet _ -> ctx
   | E_internal_return _ -> ctx
   | E_internal_value _ -> ctx
@@ -111,6 +108,10 @@ let rec exp_call_set (texp : tannot exp) (arch : arch_t) (ctx : sail_ctx) : sail
     let cfg = String.concat "." cfgs in
     add_config cfg typ ctx
 
+and fexp_call_set (fexp : 't fexp) (arch : arch_t) (ctx : sail_ctx) : sail_ctx =
+  let (FE_aux (FE_fexp (_, e), _)) = fexp in
+  exp_call_set e arch ctx
+
 and pexp_call_set (Pat_aux (pexp, _)) (arch : arch_t) (ctx : sail_ctx) : sail_ctx =
   match pexp with
   | Pat_exp (P_aux (P_id id, _), _)
@@ -119,12 +120,9 @@ and pexp_call_set (Pat_aux (pexp, _)) (arch : arch_t) (ctx : sail_ctx) : sail_ct
   | Pat_when (P_aux (P_app (id, _), _), _, _)
     when SSet.mem (string_of_id id) arch.unsupported_match -> ctx
   | Pat_exp (_, exp) -> exp_call_set exp arch ctx
-  | Pat_when (_, exp1, exp2) ->
-    ctx_union (exp_call_set exp1 arch ctx) (exp_call_set exp2 arch ctx)
+  | Pat_when (_, exp1, exp2) -> ctx |> exp_call_set exp1 arch |> exp_call_set exp2 arch
 
-and fold_set (arch : arch_t) (ctx : sail_ctx) exp =
-  ctx_union ctx (exp_call_set exp arch ctx)
-;;
+and fold_set (arch : arch_t) (ctx : sail_ctx) exp = exp_call_set exp arch ctx
 
 (* Return the ID of an application pattern as a string, or "" otherwise. *)
 let pat_app_name (P_aux (pat_aux, _)) =
@@ -161,7 +159,7 @@ let rec funcl_call_set (funcl : tannot funcl list) (arch : arch_t) (ctx : sail_c
   : sail_ctx
   =
   match funcl with
-  | h :: t -> ctx_union (func_call_set h arch ctx) (funcl_call_set t arch ctx)
+  | h :: t -> ctx |> func_call_set h arch |> funcl_call_set t arch
   | [] -> ctx
 ;;
 
@@ -194,7 +192,7 @@ let rec defs_call_set (defs : (tannot, env) def list) (arch : arch_t) (ctx : sai
   : sail_ctx
   =
   match defs with
-  | h :: t -> ctx_union (node_call_set h arch ctx) (defs_call_set t arch ctx)
+  | h :: t -> ctx |> node_call_set h arch |> defs_call_set t arch
   | [] -> ctx
 ;;
 

--- a/sail_rust_backend/rust_backend.ml
+++ b/sail_rust_backend/rust_backend.ml
@@ -1,15 +1,6 @@
 open Libsail
-open Ast
-open Ast_util
-open Jib
-open Jib_compile
-open Jib_util
 open Type_check
-open PPrint
-open Value2
 module Document = Pretty_print_sail.Document
-open Anf
-open Rust_gen
 open Call_set
 open Core_config
 module Big_int = Nat_big_num
@@ -43,7 +34,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
   (* ——————————————————————————————— Type Utils ——————————————————————————————— *)
 
   let map_union (a : 'a SMap.t) (b : 'a SMap.t) : 'a SMap.t =
-    let select key elt_a elt_b = Some elt_a in
+    let select _key elt_a _elt_b = Some elt_a in
     SMap.union select a b
   ;;
 
@@ -67,7 +58,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     }
   ;;
 
-  let defs_add_union (defs : defs) (union : unionmap) : defs =
+  let _defs_add_union (defs : defs) (union : unionmap) : defs =
     let unions = map_union union defs.unions in
     { defs with unions }
   ;;
@@ -96,7 +87,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
   (** Return true if the type is a bitvector **)
   let is_bitvector (typ : typ) : bool =
     match typ with
-    | Typ_aux (Typ_app (id, args), _) when string_of_id id = "bitvector" -> true
+    | Typ_aux (Typ_app (id, _args), _) when string_of_id id = "bitvector" -> true
     | _ -> false
   ;;
 
@@ -146,9 +137,9 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     in
     match l with
     | Parse_ast.Unknown -> None
-    | Parse_ast.Unique (n, l) -> pretty_loc l
+    | Parse_ast.Unique (_n, l) -> pretty_loc l
     | Parse_ast.Generated l -> pretty_loc l
-    | Parse_ast.Hint (_, l1, l2) -> pretty_loc l
+    | Parse_ast.Hint (_, _l1, _l2) -> pretty_loc l
     | Parse_ast.Range (lx1, lx2) ->
       let l1, l2 = lx1.pos_lnum, lx2.pos_lnum in
       let lines =
@@ -168,17 +159,17 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
   let process_scattered scattered : rs_program =
     print_string "Scattered ";
     (match scattered with
-     | SD_function (id, tannot) ->
+     | SD_function (id, _tannot) ->
        print_string "function";
        print_id id
-     | SD_funcl funcl -> print_string "funcl"
-     | SD_variant (id, typquant) ->
+     | SD_funcl _funcl -> print_string "funcl"
+     | SD_variant (id, _typquant) ->
        print_string "variant";
        print_id id
-     | SD_unioncl (id, union_type) ->
+     | SD_unioncl (id, _union_type) ->
        print_string "union";
        print_id id
-     | SD_mapping (id, tannot_opt) ->
+     | SD_mapping (id, _tannot_opt) ->
        print_string "mapping";
        print_id id
      | _ -> ());
@@ -222,9 +213,9 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     | L_bin s -> RsLitBin s
     | L_string s -> RsLitStr s
     | L_undef -> RsLitTodo
-    | L_real s -> RsLitTodo
+    | L_real _s -> RsLitTodo
 
-  and process_pat (P_aux (pat, annot)) : rs_pat =
+  and process_pat (P_aux (pat, _annot)) : rs_pat =
     match pat with
     | P_lit lit -> RsPatLit (process_lit lit)
     | P_id id -> RsPatId (sanitize_id (string_of_id id))
@@ -362,7 +353,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
             (* First, we find the type variables and contraints *)
             let kind_ids, constraints =
               match typ with
-              | Typ_aux (Typ_exist (kinded_ids, constraints, ret_typ), _) ->
+              | Typ_aux (Typ_exist (kinded_ids, constraints, _ret_typ), _) ->
                 kinded_ids, constraints
               | Typ_aux (_, l) ->
                 Reporting.warn
@@ -389,11 +380,11 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
       RsArraySize (process_exp ctx item, process_exp ctx size)
     | E_app (id, exp_list) ->
       RsApp (RsId (sanitize_id (string_of_id id)), [], List.map (process_exp ctx) exp_list)
-    | E_app_infix (exp1, id, exp2) -> RsTodo "E_app_infix"
+    | E_app_infix (_exp1, _id, _exp2) -> RsTodo "E_app_infix"
     | E_tuple exp_list -> RsTuple (List.map (process_exp ctx) exp_list)
     | E_if (exp1, exp2, exp3) ->
       RsIf (process_exp ctx exp1, process_exp ctx exp2, process_exp ctx exp3)
-    | E_loop (loop, measure, exp1, exp2) -> RsTodo "E_loop"
+    | E_loop (_loop, _measure, _exp1, _exp2) -> RsTodo "E_loop"
     | E_for (id, exp_start, exp_end, step, order, exp4) when string_of_exp step = "1" ->
       (match order with
        | Ord_aux (Ord_inc, _) ->
@@ -407,22 +398,22 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     | E_for (_, _, _, _, _, _) -> RsTodo "E_for"
     | E_vector exp_list -> process_vector ctx exp_list typ
     | E_vector_access (exp1, exp2) -> RsIndex (process_exp ctx exp1, process_exp ctx exp2)
-    | E_vector_subrange (exp1, exp2, exp3) -> RsTodo "E_vector_subrange"
-    | E_vector_update (exp1, exp2, exp3) -> RsTodo "E_vector_update"
-    | E_vector_update_subrange (exp1, exp2, exp3, exp4) -> RsTodo "E_update_subrange"
-    | E_vector_append (exp1, exp2) -> RsTodo "E_vector_append"
-    | E_list exp_list -> RsTodo "E_list"
-    | E_cons (exp1, exp2) -> RsTodo "E_cons"
+    | E_vector_subrange (_exp1, _exp2, _exp3) -> RsTodo "E_vector_subrange"
+    | E_vector_update (_exp1, _exp2, _exp3) -> RsTodo "E_vector_update"
+    | E_vector_update_subrange (_exp1, _exp2, _exp3, _exp4) -> RsTodo "E_update_subrange"
+    | E_vector_append (_exp1, _exp2) -> RsTodo "E_vector_append"
+    | E_list _exp_list -> RsTodo "E_list"
+    | E_cons (_exp1, _exp2) -> RsTodo "E_cons"
     | E_struct fexp_list ->
       let typ = typ_to_rust typ in
       RsStruct (strip_generic_parameters typ, process_fexp_entries ctx fexp_list)
-    | E_struct_update (exp, fexp_list) ->
+    | E_struct_update (_exp, fexp_list) ->
       (match fexp_list with
        (* The struct update is expexted to return the new struct with the field updated *)
        | [ FE_aux (FE_fexp (field, fexp), _) ] ->
          let struct_typ =
            match typ with
-           | Typ_aux (Typ_id id, l) -> RsTypId (string_of_id id)
+           | Typ_aux (Typ_id id, _l) -> RsTypId (string_of_id id)
            | Typ_aux (_, l) ->
              Reporting.warn
                "Could not infer struct type in field update"
@@ -446,29 +437,29 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     | E_var (lexp, value, next) ->
       RsLetMut (process_lexp ctx lexp, process_exp ctx value, process_exp ctx next)
     | E_assign (lexp, exp) -> RsAssign (process_lexp ctx lexp, process_exp ctx exp)
-    | E_sizeof nexp -> RsTodo "E_sizeof"
+    | E_sizeof _nexp -> RsTodo "E_sizeof"
     | E_return exp -> RsReturn (process_exp ctx exp)
-    | E_exit exp ->
+    | E_exit _exp ->
       RsApp (RsId "panic!", [], [ RsLit (RsLitStr "exit") ])
       (* How should we handle exits? *)
-    | E_ref id -> RsTodo "E_ref"
-    | E_throw exp ->
+    | E_ref _id -> RsTodo "E_ref"
+    | E_throw _exp ->
       RsApp (RsId "panic!", [], [ RsLit (RsLitStr "todo_process_panic_type") ])
-    | E_try (exp, pexp_list) -> RsTodo "E_try"
+    | E_try (_exp, _pexp_list) -> RsTodo "E_try"
     | E_assert (exp1, E_aux (E_lit (L_aux (L_string err_msg, _)), _)) ->
       RsApp (RsId "assert!", [], [ process_exp ctx exp1; RsLit (RsLitStr err_msg) ])
-    | E_assert (exp1, exp2) ->
+    | E_assert (exp1, _exp2) ->
       RsApp
         ( RsId "assert!"
         , []
         , [ process_exp ctx exp1
           ; RsLit (RsLitStr "[Compiler TODO] process non-trivial error messages")
           ] )
-    | E_internal_plet (pat, exp1, exp2) -> RsTodo "E_internal_plet"
-    | E_internal_return exp -> RsTodo "E_internal_return"
-    | E_internal_value value -> RsTodo "E_internal_value"
-    | E_internal_assume (n_constraint, exp) -> RsTodo "E_internal_assume"
-    | E_constraint n_constraint -> RsTodo "E_constraint"
+    | E_internal_plet (_pat, _exp1, _exp2) -> RsTodo "E_internal_plet"
+    | E_internal_return _exp -> RsTodo "E_internal_return"
+    | E_internal_value _value -> RsTodo "E_internal_value"
+    | E_internal_assume (_n_constraint, _exp) -> RsTodo "E_internal_assume"
+    | E_constraint _n_constraint -> RsTodo "E_constraint"
     | E_config cfgs ->
       (match config_find rv64_config cfgs with
        (* known values are inlined directly *)
@@ -484,7 +475,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
          (* set flag *)
          construct_fields (RsField (RsId core_ctx, "config")) cfgs)
 
-  and process_lexp (ctx : context) (LE_aux (lexp, annot)) : rs_lexp =
+  and process_lexp (ctx : context) (LE_aux (lexp, _annot)) : rs_lexp =
     match lexp with
     | LE_id id ->
       let id = sanitize_id (string_of_id id) in
@@ -499,7 +490,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
          should store that information somewhere so a transformation pass can
          re-write operations of the form `x[i] = y`, which are not supported
          in Rust for bitvectors and should use a setter method instead.
-         
+
          Here is a way to retrieve the type:
 
          ```
@@ -526,7 +517,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
       let typ = typ_to_rust typ in
       RsLexpTyp (id, typ)
 
-  and process_pexp (ctx : context) (Pat_aux (pexp, annot)) : rs_pexp =
+  and process_pexp (ctx : context) (Pat_aux (pexp, _annot)) : rs_pexp =
     match pexp with
     | Pat_exp (pat, exp) -> RsPexp (process_pat pat, process_exp ctx exp)
     | Pat_when (pat, exp1, exp2) ->
@@ -595,19 +586,19 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     | P_app (id, _) -> string_of_id id
     | _ -> ""
 
-  and process_id_pat_list id_pat_list =
+  and _process_id_pat_list id_pat_list =
     match id_pat_list with
-    | (id, pat) :: t ->
+    | (id, _pat) :: t ->
       print_string "id/pat:";
       print_id id;
-      process_id_pat_list t
+      _process_id_pat_list t
     | _ -> ()
 
-  and extract_pat_name (pat : rs_pat) : string =
+  and _extract_pat_name (pat : rs_pat) : string =
     match pat with
     | RsPatLit lit -> string_of_rs_lit lit
     | RsPatId id -> id
-    | RsPatType (typ, pat) -> string_of_rs_pat pat
+    | RsPatType (_typ, pat) -> string_of_rs_pat pat
     | RsPatWildcard -> "_"
     | _ ->
       Reporting.simple_warn "`extaract_pat_name`: pattern not implemented";
@@ -631,11 +622,11 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     in
     match typ with
     (* We expect all num types to be represented as ranges *)
-    | Typ_app (id, [ start; A_aux (A_nexp (Nexp_aux (nexp, l)), _) ])
+    | Typ_app (id, [ _start; A_aux (A_nexp (Nexp_aux (nexp, l)), _) ])
       when string_of_id id = "range" ->
       (match nexp with
        (* We expect a range of the form 2 ^ X - 1 *)
-       | Nexp_minus (Nexp_aux (Nexp_exp exponent, _), Nexp_aux (Nexp_constant n, _)) ->
+       | Nexp_minus (Nexp_aux (Nexp_exp exponent, _), Nexp_aux (Nexp_constant _n, _)) ->
          Option.map Big_int.to_int64 (big_int_of_nexp exponent)
        | _ ->
          Reporting.warn
@@ -658,19 +649,19 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
            (string_of_typ (Typ_aux (typ, l))));
       None
 
-  and process_args_pat (P_aux (pat_aux, annot)) : rs_pat list =
+  and process_args_pat (P_aux (pat_aux, _annot)) : rs_pat list =
     match pat_aux with
-    | P_app (id, [ P_aux (P_tuple pats, _) ]) ->
+    | P_app (_id, [ P_aux (P_tuple pats, _) ]) ->
       List.flatten (List.map process_args_pat pats)
     | P_app (id, pats) ->
       [ RsPatApp
           ( RsPatId (sanitize_id (string_of_id id))
           , List.flatten (List.map process_args_pat pats) )
       ]
-    | P_struct (id_pat_list, field_pat_wildcard) -> [ RsPatId "TodoArgsStruct" ]
-    | P_list pats -> [ RsPatId "TodoArgsList" ]
-    | P_var (var, typ) -> [ RsPatId "TodoArgsVar" ]
-    | P_cons (h, t) -> [ RsPatId "TodoArgsCons" ]
+    | P_struct (_id_pat_list, _field_pat_wildcard) -> [ RsPatId "TodoArgsStruct" ]
+    | P_list _pats -> [ RsPatId "TodoArgsList" ]
+    | P_var (_var, _typ) -> [ RsPatId "TodoArgsVar" ]
+    | P_cons (_h, _t) -> [ RsPatId "TodoArgsCons" ]
     | P_tuple pats -> List.flatten (List.map process_args_pat pats)
     | P_id id -> [ RsPatId (string_of_id id) ]
     | P_typ (_, pat) -> process_args_pat pat
@@ -704,8 +695,8 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     in
     let rec add_missing_args args args_type new_args : rs_pat list =
       match args, args_type with
-      | ha :: ta, ht :: tt -> add_missing_args ta tt (new_args @ [ ha ])
-      | [], ht :: tt -> add_missing_args [] tt (new_args @ [ fresh_arg () ])
+      | ha :: ta, _ :: tt -> add_missing_args ta tt (new_args @ [ ha ])
+      | [], _ :: tt -> add_missing_args [] tt (new_args @ [ fresh_arg () ])
       | _, [] -> new_args
     in
     let arg_names = process_args_pat pat in
@@ -756,7 +747,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
       match func with
       | FCL_funcl (id, pexp) -> id, pexp
     in
-    let pexp, annot =
+    let pexp, _annot =
       match pexp with
       | Pat_aux (pexp, annot) -> pexp, annot
     in
@@ -766,7 +757,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
       match pexp with
       | Pat_exp (pat, exp) ->
         RsProg [ RsFn (build_function FunKindFunc name pat exp ctx l doc_comment) ]
-      | Pat_when (pat1, exp, pat2) -> RsProg [])
+      | Pat_when (_pat1, _exp, _pat2) -> RsProg [])
     else (
       match pexp with
       | Pat_exp (pat, exp) ->
@@ -793,7 +784,8 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     | h :: t -> merge_rs_prog (process_func h s) (process_funcl t s)
     | [] -> RsProg []
 
-  and process_fundef (FD_function (rec_opt, tannot_opt, funcl)) (s : context) : rs_program
+  and process_fundef (FD_function (_rec_opt, _tannot_opt, funcl)) (s : context)
+    : rs_program
     =
     process_funcl funcl s
 
@@ -809,11 +801,11 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
 
   and process_unions (members : Ast.type_union list) : (string * rs_type option) list =
     match members with
-    | Tu_aux (Tu_ty_id (typ, id), annot) :: v ->
+    | Tu_aux (Tu_ty_id (typ, id), _annot) :: v ->
       (string_of_id id, Some (typ_to_rust typ)) :: process_unions v
     | [] -> []
 
-  and typequant_to_generics (TypQ_aux (_, l) as typq : typquant) : rs_generic list =
+  and typequant_to_generics (TypQ_aux _ as typq : typquant) : rs_generic list =
     let kset = ref KidSet.empty in
     let tyvars_of_quant_item (QI_aux (qi, _)) : (kind * kid) option =
       match qi with
@@ -869,7 +861,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
   and typdef_to_rust (s : context) (TD_aux (typ, (l, _))) : rs_program =
     match typ with
     | TD_enum (id, members, _) -> RsProg [ RsEnum (enum_to_rust id members l) ]
-    | TD_variant (id, typq, members, _) when string_of_id id = "option" ->
+    | TD_variant (id, _typq, _members, _) when string_of_id id = "option" ->
       RsProg [] (* Special semantics in rust *)
     | TD_variant (id, typq, members, _) ->
       RsProg [ RsEnum (variant_to_rust id typq members l) ]
@@ -886,7 +878,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
       RsProg [ RsAlias alias ]
     (* TODO *)
     (* NOTE: we should create a constant for numeral types only if there is no constant with the same name already defined. *)
-    | TD_abbrev (id, typq, A_aux (A_nexp nexp, _))
+    | TD_abbrev (id, _typq, A_aux (A_nexp nexp, _))
       when not (SSet.mem (string_of_id id) s.defs.constants) ->
       let value =
         match big_int_of_nexp nexp with
@@ -898,7 +890,8 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     | TD_abbrev _ -> RsProg [] (* Ignore all other abbreviations *)
     | _ -> RsProg []
 
-  and toplevel_let_to_rust (LB_aux (LB_val (pat, exp), aux)) (ctx : context) : rs_program =
+  and toplevel_let_to_rust (LB_aux (LB_val (pat, exp), _aux)) (ctx : context) : rs_program
+    =
     let pat = process_pat pat in
     let rexp = process_exp ctx exp in
     let rexp = Rust_transform.simplify_rs_exp ctx rexp in
@@ -911,12 +904,12 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
       RsProg [ RsConst const ]
     | _ -> RsProg []
 
-  and def_to_rust (DEF_aux (def, annot)) (s : context) : rs_program =
+  and def_to_rust (DEF_aux (def, _annot)) (s : context) : rs_program =
     match def with
-    | DEF_register (DEC_aux (dec_spec, annot)) ->
+    | DEF_register (DEC_aux (_dec_spec, _annot)) ->
       RsProg [] (* We handle registers in a previous pass *)
-    | DEF_scattered (SD_aux (scattered, annot)) -> process_scattered scattered
-    | DEF_fundef (FD_aux (fundef, annot)) -> process_fundef fundef s
+    | DEF_scattered (SD_aux (scattered, _annot)) -> process_scattered scattered
+    | DEF_fundef (FD_aux (fundef, _annot)) -> process_fundef fundef s
     | DEF_impl funcl -> process_func funcl s
     | DEF_type typ -> typdef_to_rust s typ
     | DEF_let binding -> toplevel_let_to_rust binding s
@@ -934,9 +927,9 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
 
   and gather_registers defs : (string * rs_type * 'a exp option) list =
     match defs with
-    | DEF_aux (DEF_register (DEC_aux (dec_spec, annot)), _) :: t ->
+    | DEF_aux (DEF_register (DEC_aux (dec_spec, _annot)), _) :: t ->
       process_register dec_spec :: gather_registers t
-    | h :: t -> gather_registers t
+    | _ :: t -> gather_registers t
     | [] -> []
 
   (** We decompose the configuration into multiple Rust struct to stay close
@@ -1047,7 +1040,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
       let core = RsId core_ctx in
       let initialize_reg (name, _, exp) =
         match exp with
-        | Some exp ->
+        | Some _exp ->
           let app = RsApp (RsId ("_reset_" ^ name), [], []) in
           Some (RsAssign (RsLexpField (core, name), app))
         | None -> None
@@ -1082,7 +1075,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     | _ -> RsTodo "TodoNConstraint"
 
   and nexp_to_rs_exp (nexp : nexp) : rs_exp =
-    let (Nexp_aux (nexp, l)) = nexp_simp nexp in
+    let (Nexp_aux (nexp, _)) = nexp_simp nexp in
     match nexp with
     | Nexp_constant n -> mk_big_num n
     | Nexp_times (n, m) -> RsBinop (nexp_to_rs_exp n, RsBinopMult, nexp_to_rs_exp m)
@@ -1100,8 +1093,8 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     | Nexp_neg n -> RsUnop (RsUnopNeg, nexp_to_rs_exp n)
     | Nexp_id id -> RsId (string_of_id id)
     | Nexp_var kid -> RsId (sanitize_generic_id (string_of_kid kid)) (* variable *)
-    | Nexp_app (fn, args) -> RsTodo "TodoAppExpr" (* app *)
-    | Nexp_if (cond, if_block, else_block) -> RsTodo "TodoIfExpr" (* if-then-else *)
+    | Nexp_app (_fn, _args) -> RsTodo "TodoAppExpr" (* app *)
+    | Nexp_if (_cond, _if_block, _else_block) -> RsTodo "TodoIfExpr" (* if-then-else *)
 
   and get_first_two_elements lst =
     assert (List.length lst = 2);
@@ -1171,7 +1164,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     (* We ignore the type quantifier for now, there is no `forall` on most types of interest *)
     let (TypSchm_ts (typq, typ)) = typeschm in
     let generics = typequant_to_generics typq in
-    let (Typ_aux (typ, l)) = typ in
+    let (Typ_aux (typ, _l)) = typ in
     match typ with
     (* When Sail infers type, it sometimes uses a single tuple as argument.
                In such cases, we flatten the tuple. *)
@@ -1185,7 +1178,7 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
 
   let val_fun_def (val_spec : val_spec_aux) : defmap =
     let map = SMap.empty in
-    let (VS_val_spec (typeschm, id, extern)) = val_spec in
+    let (VS_val_spec (typeschm, id, _extern)) = val_spec in
     let id = string_of_id id in
     (* print_string id; *)
     (* print_string ": "; *)
@@ -1211,10 +1204,10 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
 
   let type_def_fun_def (TD_aux (typ, _)) : unionmap =
     match typ with
-    | TD_abbrev (id, typquant, typ_arg) -> SMap.empty
-    | TD_record (id, typquant, items, _) -> SMap.empty
-    | TD_variant (id, typquant, members, _) -> type_union_defs members
-    | TD_enum (id, member, _) -> SMap.empty
+    | TD_abbrev (_id, _typquant, _typ_arg) -> SMap.empty
+    | TD_record (_id, _typquant, _items, _) -> SMap.empty
+    | TD_variant (_id, _typquant, members, _) -> type_union_defs members
+    | TD_enum (_id, _member, _) -> SMap.empty
     | TD_bitfield _ -> SMap.empty
     | _ ->
       print_endline "TypeFunDef: other";
@@ -1223,13 +1216,13 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
 
   (* ——————————————————————— Iterating over definitions ——————————————————————— *)
 
-  let node_defs (DEF_aux (def, annot)) : defs =
+  let node_defs (DEF_aux (def, _annot)) : defs =
     match def with
-    | DEF_val (VS_aux (val_spec, annot)) -> defs_from_funs (val_fun_def val_spec)
-    | DEF_register (DEC_aux (dec_spec, annot)) -> defs_empty
-    | DEF_scattered (SD_aux (scattered, annot)) -> defs_empty
-    | DEF_fundef (FD_aux (fundef, annot)) -> defs_empty
-    | DEF_impl funcl -> defs_empty
+    | DEF_val (VS_aux (val_spec, _annot)) -> defs_from_funs (val_fun_def val_spec)
+    | DEF_register (DEC_aux (_dec_spec, _annot)) -> defs_empty
+    | DEF_scattered (SD_aux (_scattered, _annot)) -> defs_empty
+    | DEF_fundef (FD_aux (_fundef, _annot)) -> defs_empty
+    | DEF_impl _funcl -> defs_empty
     | DEF_type typ -> defs_from_union (type_def_fun_def typ)
     | DEF_let (LB_aux (LB_val (pat, _), _)) ->
       let pat = process_pat pat in
@@ -1262,12 +1255,12 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
   let rec ast_union_type_list_to_string_list (members : Ast.type_union list) : string list
     =
     match members with
-    | Tu_aux (Tu_ty_id (typ, id), annot) :: v ->
+    | Tu_aux (Tu_ty_id (_typ, id), _annot) :: v ->
       string_of_id id :: ast_union_type_list_to_string_list v
     | [] -> []
   ;;
 
-  let process_enum_entries_aux (DEF_aux (def, annot)) : (string * string) list =
+  let process_enum_entries_aux (DEF_aux (def, _annot)) : (string * string) list =
     match def with
     | DEF_type (TD_aux (TD_enum (id, members, _), _)) ->
       gen_enum_list id (ast_id_list_to_string_list members)
@@ -1298,13 +1291,13 @@ module Codegen (CodegenConfig : CODEGEN_CONFIG) = struct
     let rec funs obj =
       match obj with
       | RsFn fn :: tail -> (fn.name, fn) :: funs tail
-      | head :: tail -> funs tail
+      | _head :: tail -> funs tail
       | [] -> []
     in
     funs obj
   ;;
 
-  let compile_ast env effect_info ast =
+  let compile_ast _env _effect_info ast =
     try
       (* Compute call set *)
       let sail_ctx = get_call_set CodegenConfig.arch ast in

--- a/sail_rust_backend/rust_backend.mli
+++ b/sail_rust_backend/rust_backend.mli
@@ -5,6 +5,6 @@ module type CODEGEN_CONFIG = sig
   val arch : Types.arch_t
 end
 
-module Codegen (CodegenConfig : CODEGEN_CONFIG) : sig
+module Codegen (_ : CODEGEN_CONFIG) : sig
   val compile_ast : Env.t -> Effects.side_effect_info -> typed_ast -> string
 end

--- a/sail_rust_backend/rust_gen.ml
+++ b/sail_rust_backend/rust_gen.ml
@@ -233,7 +233,7 @@ let rec strip_generic_parameters (typ : rs_type) : rs_type =
   in
   match typ with
   | RsTypTuple typs -> RsTypTuple (List.map strip_generic_parameters typs)
-  | RsTypGenericParam (name, gen_params) -> RsTypId name
+  | RsTypGenericParam (name, _) -> RsTypId name
   | RsTypArray (typ, size) -> RsTypArray (strip_typ_params typ, strip_typ_params size)
   | RsTypOption typ -> RsTypOption (strip_typ_params typ)
   | _ -> typ
@@ -280,11 +280,11 @@ and generics_of_exp (exp : rs_exp) : SSet.t =
     generics_of_exp app
     |> SSet.union (SSet.of_list gens)
     |> SSet.union (generics_of_exps args)
-  | RsMethodApp { exp; generics = gens; args } ->
+  | RsMethodApp { exp; generics = gens; args; name = _ } ->
     generics_of_exp exp
     |> SSet.union (SSet.of_list gens)
     |> SSet.union (generics_of_exps args)
-  | RsStaticApp (typ, name, args) ->
+  | RsStaticApp (typ, _, args) ->
     generics_of_typ typ |> SSet.union (generics_of_exps args)
   | RsId id -> if id_is_generic id then SSet.singleton id else SSet.empty
   | RsLit _ -> SSet.empty
@@ -427,7 +427,7 @@ let string_of_const (const : bool) : string = if const then "const " else ""
 
 let string_of_derive (derive : string list) : string =
   match derive with
-  | head :: tail -> "#[derive(" ^ String.concat ", " derive ^ ")]\n"
+  | _ :: _ -> "#[derive(" ^ String.concat ", " derive ^ ")]\n"
   | [] -> ""
 ;;
 

--- a/sail_rust_backend/rust_transform.ml
+++ b/sail_rust_backend/rust_transform.ml
@@ -11,12 +11,12 @@ module Big_int = Libsail.Ast_util.Big_int
 
 (* ————————————————————————— Transform Expressions —————————————————————————— *)
 
-let id_exp (ctx : context) (exp : rs_exp) : rs_exp = exp
-let id_lexp (ctx : context) (lexp : rs_lexp) : rs_lexp = lexp
-let id_pexp (ctx : context) (pexp : rs_pexp) : rs_pexp = pexp
-let id_typ (ctx : context) (typ : rs_type) : rs_type = typ
-let id_pat (ctx : context) (pat : rs_pat) : rs_pat = pat
-let id_obj (ctx : context) (obj : rs_obj) : rs_obj = obj
+let id_exp (_ctx : context) (exp : rs_exp) : rs_exp = exp
+let id_lexp (_ctx : context) (lexp : rs_lexp) : rs_lexp = lexp
+let id_pexp (_ctx : context) (pexp : rs_pexp) : rs_pexp = pexp
+let id_typ (_ctx : context) (typ : rs_type) : rs_type = typ
+let id_pat (_ctx : context) (pat : rs_pat) : rs_pat = pat
+let id_obj (_ctx : context) (obj : rs_obj) : rs_obj = obj
 
 type expr_type_transform =
   { exp : context -> rs_exp -> rs_exp
@@ -40,7 +40,7 @@ let rec transform_pat (ct : expr_type_transform) (ctx : context) (pat : rs_pat) 
   | RsPatWildcard -> RsPatWildcard
   | RsPatLit l -> RsPatLit l
   | RsPatId id -> RsPatId id
-  | RsPatApp (RsPatId "None", args) -> RsPatNone
+  | RsPatApp (RsPatId "None", _args) -> RsPatNone
   | RsPatApp (name, args) ->
     RsPatApp (transform_pat ct ctx name, List.map (fun p -> transform_pat ct ctx p) args)
   | RsPatSome pat -> RsPatSome (transform_pat ct ctx pat)
@@ -185,7 +185,7 @@ and transform_type (ct : expr_type_transform) (ctx : context) (typ : rs_type) : 
   | RsTypTuple types -> RsTypTuple (List.map (transform_type ct ctx) types)
   | RsTypGeneric typ -> RsTypGeneric typ
   (* TODO: Maybe there is a bug here *)
-  | RsTypGenericParam (typ, e :: params) when typ = "option" ->
+  | RsTypGenericParam (typ, e :: _params) when typ = "option" ->
     RsTypOption (transform_type_param ct ctx e)
   | RsTypGenericParam (typ, params) ->
     RsTypGenericParam (typ, List.map (transform_type_param ct ctx) params)
@@ -197,7 +197,7 @@ and transform_type (ct : expr_type_transform) (ctx : context) (typ : rs_type) : 
 (* ———————————————————————— Expression and Type transformer ————————————————————————— *)
 
 let transform_fn (ct : expr_type_transform) (ctx : context) (fn : rs_fn) : rs_fn =
-  let { generics; args; ret } = fn.signature in
+  let { generics; args; ret; linked_gen_args = _ } = fn.signature in
   let args = List.map (transform_type ct ctx) args in
   let ret = transform_type ct ctx ret in
   { fn with
@@ -288,8 +288,8 @@ let bitvec_transform_match_tuple (exp : rs_exp list) (patterns : rs_pat list) : 
 
 let parse_first_tuple_entry (values : rs_pexp list) : rs_pat list =
   match values with
-  | RsPexp (RsPatTuple t, _) :: rest -> t
-  | RsPexpWhen (RsPatTuple t, _, _) :: rest -> t
+  | RsPexp (RsPatTuple t, _) :: _rest -> t
+  | RsPexpWhen (RsPatTuple t, _, _) :: _rest -> t
   | _ ->
     Reporting.simple_warn
       ("Unexpected patterns: | "
@@ -297,12 +297,12 @@ let parse_first_tuple_entry (values : rs_pexp list) : rs_pat list =
     failwith "Code should be unreachable"
 ;;
 
-let bitvec_transform_exp (ctx : context) (exp : rs_exp) : rs_exp =
+let bitvec_transform_exp (_ctx : context) (exp : rs_exp) : rs_exp =
   let one = Big_int.of_int 1 in
   match exp with
   | RsApp
       ( RsId "subrange_bits"
-      , generics
+      , _generics
       , [ RsField (bitvec, "bits"); RsLit (RsLitNum r_end); RsLit (RsLitNum r_start) ] )
     ->
     let r_end = Big_int.add r_end (Big_int.of_int 1) in
@@ -316,7 +316,7 @@ let bitvec_transform_exp (ctx : context) (exp : rs_exp) : rs_exp =
       }
   | RsApp
       ( RsId "subrange_bits"
-      , generics
+      , _generics
       , [ RsId id; RsLit (RsLitNum r_end); RsLit (RsLitNum r_start) ] ) ->
     let r_end = Big_int.add r_end (Big_int.of_int 1) in
     let r_size = Big_int.sub r_end r_start in
@@ -340,15 +340,15 @@ let bitvec_transform_exp (ctx : context) (exp : rs_exp) : rs_exp =
       }
     in
     RsAssign (lexp, RsMethodApp method_app)
-  | RsApp (RsId "zero_extend", generics, [ RsLit (RsLitNum size); e ]) ->
+  | RsApp (RsId "zero_extend", _generics, [ RsLit (RsLitNum size); e ]) ->
     RsMethodApp
       { exp = e; name = "zero_extend"; generics = [ Big_int.to_string size ]; args = [] }
   (* The size is given as a constant, force the return dimension with a generic *)
-  | RsApp (RsId "sail_zero_extend", generics, [ e; RsLit (RsLitNum size) ]) ->
+  | RsApp (RsId "sail_zero_extend", _generics, [ e; RsLit (RsLitNum size) ]) ->
     RsMethodApp
       { exp = e; name = "zero_extend"; generics = [ Big_int.to_string size ]; args = [] }
   (* If the size is not a constant, then rely on Rust type inference *)
-  | RsApp (RsId "sail_zero_extend", generics, [ e; size ]) ->
+  | RsApp (RsId "sail_zero_extend", _generics, [ e; _size ]) ->
     RsMethodApp { exp = e; name = "zero_extend"; generics = []; args = [] }
   | RsMatch (exp, pat :: pats) when is_bitvec_lit pat ->
     let method_app = { exp; name = "bits"; generics = []; args = [] } in
@@ -370,7 +370,7 @@ and uint_to_bitvector (n : int) : rs_type =
   else RsTypId "InvalidBitVectorSize"
 ;;
 
-let rec bitvec_transform_type (ctx : context) (typ : rs_type) : rs_type =
+let bitvec_transform_type (_ctx : context) (typ : rs_type) : rs_type =
   match typ with
   | RsTypGenericParam ("bitvector", t) -> RsTypGenericParam ("BitVector", t)
   | RsTypGenericParam ("bits", t) -> RsTypGenericParam ("BitVector", t)
@@ -409,7 +409,7 @@ let rec find_match_branch_opt (n : Big_int.num) (branches : rs_pexp list) =
 (** Simplifies rust expression by applying basic optimisations.
 
  For now, this mostly includes arithmetic operators.**)
-let rec simplify_rs_exp (ctx : context) (rs_exp : rs_exp) : rs_exp =
+let simplify_rs_exp (ctx : context) (rs_exp : rs_exp) : rs_exp =
   match rs_exp with
   | RsBinop (RsLit (RsLitNum a), RsBinopAdd, RsLit (RsLitNum b)) ->
     RsLit (RsLitNum (Big_int.add a b))
@@ -433,19 +433,19 @@ let rec simplify_rs_exp (ctx : context) (rs_exp : rs_exp) : rs_exp =
            for their side effects, then this will introduce logic bugs. We
            could imagine tracking function purity in the future to work around
            that limitation. *)
-  | RsBinop (RsLit RsLitFalse, RsBinopLAnd, exp)
-  | RsBinop (exp, RsBinopLAnd, RsLit RsLitFalse) -> RsLit RsLitFalse
+  | RsBinop (RsLit RsLitFalse, RsBinopLAnd, _exp)
+  | RsBinop (_exp, RsBinopLAnd, RsLit RsLitFalse) -> RsLit RsLitFalse
   (* NOTE: here we assume there is no side effects in the condition
            checks. is it is expected that some expression should be performed
            for their side effects, then this will introduce logic bugs. We
            could imagine tracking function purity in the future to work around
            that limitation. *)
-  | RsBinop (RsLit RsLitTrue, RsBinopLOr, exp) | RsBinop (exp, RsBinopLOr, RsLit RsLitTrue)
-    -> RsLit RsLitTrue
+  | RsBinop (RsLit RsLitTrue, RsBinopLOr, _exp)
+  | RsBinop (_exp, RsBinopLOr, RsLit RsLitTrue) -> RsLit RsLitTrue
   | RsBinop (RsLit RsLitFalse, RsBinopLOr, exp)
   | RsBinop (exp, RsBinopLOr, RsLit RsLitFalse) -> exp
-  | RsIf (RsLit RsLitTrue, if_branch, else_branch) -> if_branch
-  | RsIf (RsLit RsLitFalse, if_branch, else_branch) -> else_branch
+  | RsIf (RsLit RsLitTrue, if_branch, _else_branch) -> if_branch
+  | RsIf (RsLit RsLitFalse, _if_branch, else_branch) -> else_branch
   | RsMatch (RsLit (RsLitNum n), branches) ->
     (match find_match_branch_opt n branches with
      | Some exp -> exp
@@ -462,10 +462,10 @@ let rec simplify_rs_exp (ctx : context) (rs_exp : rs_exp) : rs_exp =
      | [ RsPexp (RsPatWildcard, exp) ] -> exp
      | _ -> RsMatch (exp, branches))
   | RsApp
-      ( RsPathSeparator (int_typ, RsTypId "pow")
+      ( RsPathSeparator (_int_typ, RsTypId "pow")
       , []
       , [ RsLit (RsLitNum n); RsAs (RsLit (RsLitNum m), _) ] )
-  | RsStaticApp (int_typ, "pow", [ RsLit (RsLitNum n); RsAs (RsLit (RsLitNum m), _) ]) ->
+  | RsStaticApp (_int_typ, "pow", [ RsLit (RsLitNum n); RsAs (RsLit (RsLitNum m), _) ]) ->
     mk_big_num (Big_int.pow_int n (Big_int.to_int m))
   | RsApp (RsId id, _, _) when SMap.mem id ctx.defs.inline_fun ->
     SMap.find id ctx.defs.inline_fun
@@ -612,7 +612,7 @@ let constant_propagation (program : rs_program) : rs_program =
 
 (** Sail often generates blocks in constructs such as if statements, for which
     we already have blocks. This transformation removes the nested blocks. **)
-let nested_block_remover_exp (ctx : context) (exp : rs_exp) : rs_exp =
+let nested_block_remover_exp (_ctx : context) (exp : rs_exp) : rs_exp =
   match exp with
   | RsIf (c, RsBlock e1, RsBlock e2) -> RsIf (c, RsInstrList e1, RsInstrList e2)
   | RsIf (c, RsBlock e1, e2) -> RsIf (c, RsInstrList e1, e2)
@@ -645,114 +645,116 @@ let unsupported_fun : SSet.t =
 ;;
 
 (* TODO: This list is probably incomplete and we might want to add extra fields in the future *)
-let native_func_transform_exp (ctx : context) (exp : rs_exp) : rs_exp =
+let native_func_transform_exp (_ctx : context) (exp : rs_exp) : rs_exp =
   match exp with
-  | RsApp (RsId "add_atom", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopAdd, e2)
-  | RsApp (RsId "sub_atom", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopSub, e2)
-  | RsApp (RsId "negate_atom", gens, [ e1 ]) -> RsUnop (RsUnopNeg, e1)
-  | RsApp (RsId "ediv_int", gens, _) -> RsId "BUILTIN_atom_ediv_TODO"
-  | RsApp (RsId "emod_int", gens, [ e1; e2 ]) ->
+  | RsApp (RsId "add_atom", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopAdd, e2)
+  | RsApp (RsId "sub_atom", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopSub, e2)
+  | RsApp (RsId "negate_atom", _gens, [ e1 ]) -> RsUnop (RsUnopNeg, e1)
+  | RsApp (RsId "ediv_int", _gens, _) -> RsId "BUILTIN_atom_ediv_TODO"
+  | RsApp (RsId "emod_int", _gens, [ e1; e2 ]) ->
     RsBinop (RsAs (e1, usize_typ), RsBinopMod, RsAs (e2, usize_typ))
-  | RsApp (RsId "abs_int_atom", gens, [ e ]) -> RsStaticApp (int_typ, "abs", [ e ])
-  | RsApp (RsId "not_bool", gens, [ e ]) -> RsUnop (RsUnopNot, e)
-  | RsApp (RsId "not_vec", gens, [ v ]) -> RsUnop (RsUnopNot, v)
-  | RsApp (RsId "eq_bit", gens, [ e1; e2 ]) ->
+  | RsApp (RsId "abs_int_atom", _gens, [ e ]) -> RsStaticApp (int_typ, "abs", [ e ])
+  | RsApp (RsId "not_bool", _gens, [ e ]) -> RsUnop (RsUnopNot, e)
+  | RsApp (RsId "not_vec", _gens, [ v ]) -> RsUnop (RsUnopNot, v)
+  | RsApp (RsId "eq_bit", _gens, [ e1; e2 ]) ->
     RsBinop (e1, RsBinopEq, e2) (* TODO Is it correct to compare like that? *)
-  | RsApp (RsId "eq_bool", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopEq, e2)
-  | RsApp (RsId "eq_string", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopEq, e2)
-  | RsApp (RsId "eq_int", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopEq, e2)
-  | RsApp (RsId "not", gens, [ b ]) -> RsUnop (RsUnopNot, b)
-  | RsApp (RsId "lt", gens, _) -> RsId "BUILTIN_lt_TODO"
-  | RsApp (RsId "lteq", gens, _) -> RsId "BUILTIN_lteq_TODO"
-  | RsApp (RsId "lteq_int", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopLe, e2)
-  | RsApp (RsId "gt", gens, _) -> RsId "BUILTIN_gt_TODO"
-  | RsApp (RsId "gteq", gens, _) -> RsId "BUILTIN_gteq_TODO"
+  | RsApp (RsId "eq_bool", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopEq, e2)
+  | RsApp (RsId "eq_string", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopEq, e2)
+  | RsApp (RsId "eq_int", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopEq, e2)
+  | RsApp (RsId "not", _gens, [ b ]) -> RsUnop (RsUnopNot, b)
+  | RsApp (RsId "lt", _gens, _) -> RsId "BUILTIN_lt_TODO"
+  | RsApp (RsId "lteq", _gens, _) -> RsId "BUILTIN_lteq_TODO"
+  | RsApp (RsId "lteq_int", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopLe, e2)
+  | RsApp (RsId "gt", _gens, _) -> RsId "BUILTIN_gt_TODO"
+  | RsApp (RsId "gteq", _gens, _) -> RsId "BUILTIN_gteq_TODO"
   | RsApp (RsId "vector_length", gens, [ vec ]) ->
     RsMethodApp { exp = vec; name = "len"; generics = gens; args = [] }
-  | RsApp (RsId "add_int", gens, _) -> RsId "BUILTIN_add_int_TODO"
-  | RsApp (RsId "sub_int", gens, _) -> RsId "BUILTIN_sub_int_TODO"
-  | RsApp (RsId "mult_int", gens, _) -> RsId "BUILTIN_mult_int_TODO"
-  | RsApp (RsId "neg_int", gens, _) -> RsId "BUILTIN_neg_int_TODO"
-  | RsApp (RsId "abs_int", gens, _) -> RsId "BUILTIN_abs_int_TODO"
-  | RsApp (RsId "max_int", gens, _) -> RsId "BUILTIN_max_int_TODO"
-  (*| RsApp (RsId "min_int", gens, _) -> RsId "BUILTIN_min_int_TODO" *)
-  | RsApp (RsId "tdiv_int", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopDiv, e2)
-  | RsApp (RsId "tmod_int", gens, _) -> RsId "BUILTIN_tmod_int_TODO"
+  | RsApp (RsId "add_int", _gens, _) -> RsId "BUILTIN_add_int_TODO"
+  | RsApp (RsId "sub_int", _gens, _) -> RsId "BUILTIN_sub_int_TODO"
+  | RsApp (RsId "mult_int", _gens, _) -> RsId "BUILTIN_mult_int_TODO"
+  | RsApp (RsId "neg_int", _gens, _) -> RsId "BUILTIN_neg_int_TODO"
+  | RsApp (RsId "abs_int", _gens, _) -> RsId "BUILTIN_abs_int_TODO"
+  | RsApp (RsId "max_int", _gens, _) -> RsId "BUILTIN_max_int_TODO"
+  (*| RsApp (RsId "min_int", _gens, _) -> RsId "BUILTIN_min_int_TODO" *)
+  | RsApp (RsId "tdiv_int", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopDiv, e2)
+  | RsApp (RsId "tmod_int", _gens, _) -> RsId "BUILTIN_tmod_int_TODO"
   | RsApp (RsId "pow2", [], [ n ]) ->
     RsApp
       (RsPathSeparator (int_typ, RsTypId "pow"), [], [ mk_num 2; RsAs (n, RsTypId "u32") ])
   | RsApp (RsId "quot_positive_round_zero", [], [ a; b ]) -> RsBinop (a, RsBinopDiv, b)
-  (* | RsApp (RsId "zeros", gens, _) -> RsId "BUILTIN_zeros_TODO" *)
-  (*| RsApp (RsId "ones", gens, e) -> RsApp (RsId "ones", e) Handled by the integrated library *)
+  (* | RsApp (RsId "zeros", _gens, _) -> RsId "BUILTIN_zeros_TODO" *)
+  (*| RsApp (RsId "ones", _gens, e) -> RsApp (RsId "ones", e) Handled by the integrated library *)
   (* Implemented in lib.sail *)
-  (*| RsApp (RsId "zero_extend", gens, e) -> RsApp (RsId "zero_extend", e)
-    | RsApp (RsId "sign_extend", gens, e) -> RsApp (RsId "sign_extend", e)
-    | RsApp (RsId "sail_ones", gens, e) -> RsApp (RsId "sail_ones", e) *)
-  | RsApp (RsId "sail_signed", gens, _) -> RsId "BUILTIN_sail_signed_TODO"
-  | RsApp (RsId "sail_unsigned", gens, _) -> RsId "BUILTIN_sail_unsigned_TODO"
-  | RsApp (RsId "slice", gens, args) -> RsApp (RsId "slice", [], args)
-  | RsApp (RsId "slice_inc", gens, _) -> RsId "BUILTIN_slice_inc_TODO"
-  | RsApp (RsId "add_bits", gens, _) -> RsId "BUILTIN_add_bits_TODO"
-  | RsApp (RsId "add_bits_int", gens, [ b1; b2 ]) -> RsBinop (b1, RsBinopAdd, b2)
-  | RsApp (RsId "sub_bits", gens, _) -> RsId "BUILTIN_sub_bits_TODO"
-  | RsApp (RsId "sub_bits_int", gens, _) -> RsId "BUILTIN_sub_bits_int_TODO"
-  | RsApp (RsId "append", gens, _) -> RsId "BUILTIN_append_TODO"
-  | RsApp (RsId "eq_bits", gens, _) -> RsId "BUILTIN_eq_bits_TODO"
-  | RsApp (RsId "neq_bits", gens, _) -> RsId "BUILTIN_neq_bits_TODO"
-  | RsApp (RsId "not_bits", gens, _) -> RsId "BUILTIN_not_bits_TODO"
-  | RsApp (RsId "sail_truncate", gens, _) -> RsId "BUILTIN_sail_truncate_TODO"
-  | RsApp (RsId "sail_truncateLSB", gens, _) -> RsId "BUILTIN_sail_truncateLSB_TODO"
-  | RsApp (RsId "shiftl", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopShiftLeft, e2)
-  | RsApp (RsId "shiftr", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopShiftRight, e2)
-  | RsApp (RsId "arith_shiftr", gens, _) -> RsId "BUILTIN_arith_shiftr_TODO"
-  | RsApp (RsId "and_bits", gens, _) -> RsId "BUILTIN_and_bits_TODO"
-  | RsApp (RsId "or_bits", gens, _) -> RsId "BUILTIN_or_bits_TODO"
-  | RsApp (RsId "xor_bits", gens, _) -> RsId "BUILTIN_xor_bits_TODO"
-  | RsApp (RsId "vector_init", gens, _) -> RsId "BUILTIN_vector_init_TODO"
-  | RsApp (RsId "vector_access", gens, _) -> RsId "BUILTIN_vector_access_TODO"
-  | RsApp (RsId "vector_access_inc", gens, _) -> RsId "BUILTIN_vector_access_inc_TODO"
-  | RsApp (RsId "vector_subrange", gens, _) -> RsId "BUILTIN_vector_subrange_TODO"
-  | RsApp (RsId "vector_subrange_inc", gens, _) -> RsId "BUILTIN_vector_subrange_inc_TODO"
-  | RsApp (RsId "vector_update", gens, _) -> RsId "BUILTIN_vector_update_TODO"
-  | RsApp (RsId "vector_update_inc", gens, _) -> RsId "BUILTIN_vector_update_inc_TODO"
-  | RsApp (RsId "vector_update_subrange", gens, _) ->
+  (*| RsApp (RsId "zero_extend", _gens, e) -> RsApp (RsId "zero_extend", e)
+    | RsApp (RsId "sign_extend", _gens, e) -> RsApp (RsId "sign_extend", e)
+    | RsApp (RsId "sail_ones", _gens, e) -> RsApp (RsId "sail_ones", e) *)
+  | RsApp (RsId "sail_signed", _gens, _) -> RsId "BUILTIN_sail_signed_TODO"
+  | RsApp (RsId "sail_unsigned", _gens, _) -> RsId "BUILTIN_sail_unsigned_TODO"
+  | RsApp (RsId "slice", _gens, args) -> RsApp (RsId "slice", [], args)
+  | RsApp (RsId "slice_inc", _gens, _) -> RsId "BUILTIN_slice_inc_TODO"
+  | RsApp (RsId "add_bits", _gens, _) -> RsId "BUILTIN_add_bits_TODO"
+  | RsApp (RsId "add_bits_int", _gens, [ b1; b2 ]) -> RsBinop (b1, RsBinopAdd, b2)
+  | RsApp (RsId "sub_bits", _gens, _) -> RsId "BUILTIN_sub_bits_TODO"
+  | RsApp (RsId "sub_bits_int", _gens, _) -> RsId "BUILTIN_sub_bits_int_TODO"
+  | RsApp (RsId "append", _gens, _) -> RsId "BUILTIN_append_TODO"
+  | RsApp (RsId "eq_bits", _gens, _) -> RsId "BUILTIN_eq_bits_TODO"
+  | RsApp (RsId "neq_bits", _gens, _) -> RsId "BUILTIN_neq_bits_TODO"
+  | RsApp (RsId "not_bits", _gens, _) -> RsId "BUILTIN_not_bits_TODO"
+  | RsApp (RsId "sail_truncate", _gens, _) -> RsId "BUILTIN_sail_truncate_TODO"
+  | RsApp (RsId "sail_truncateLSB", _gens, _) -> RsId "BUILTIN_sail_truncateLSB_TODO"
+  | RsApp (RsId "shiftl", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopShiftLeft, e2)
+  | RsApp (RsId "shiftr", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopShiftRight, e2)
+  | RsApp (RsId "arith_shiftr", _gens, _) -> RsId "BUILTIN_arith_shiftr_TODO"
+  | RsApp (RsId "and_bits", _gens, _) -> RsId "BUILTIN_and_bits_TODO"
+  | RsApp (RsId "or_bits", _gens, _) -> RsId "BUILTIN_or_bits_TODO"
+  | RsApp (RsId "xor_bits", _gens, _) -> RsId "BUILTIN_xor_bits_TODO"
+  | RsApp (RsId "vector_init", _gens, _) -> RsId "BUILTIN_vector_init_TODO"
+  | RsApp (RsId "vector_access", _gens, _) -> RsId "BUILTIN_vector_access_TODO"
+  | RsApp (RsId "vector_access_inc", _gens, _) -> RsId "BUILTIN_vector_access_inc_TODO"
+  | RsApp (RsId "vector_subrange", _gens, _) -> RsId "BUILTIN_vector_subrange_TODO"
+  | RsApp (RsId "vector_subrange_inc", _gens, _) ->
+    RsId "BUILTIN_vector_subrange_inc_TODO"
+  | RsApp (RsId "vector_update", _gens, _) -> RsId "BUILTIN_vector_update_TODO"
+  | RsApp (RsId "vector_update_inc", _gens, _) -> RsId "BUILTIN_vector_update_inc_TODO"
+  | RsApp (RsId "vector_update_subrange", _gens, _) ->
     RsId "BUILTIN_vector_update_subrange_TODO"
-  | RsApp (RsId "vector_update_subrange_inc", gens, _) ->
+  | RsApp (RsId "vector_update_subrange_inc", _gens, _) ->
     RsId "BUILTIN_vector_update_subrange_inc_TODO"
-  | RsApp (RsId "length", gens, _) -> RsId "BUILTIN_length_TODO"
-  | RsApp (RsId "replicate_bits", gens, _) -> RsId "BUILTIN_replicate_bits_TODO"
-  | RsApp (RsId "count_leading_zeros", gens, _) -> RsId "BUILTIN_count_leading_zeros_TODO"
-  | RsApp (RsId "eq_real", gens, _) -> RsId "BUILTIN_eq_real_TODO"
-  | RsApp (RsId "neg_real", gens, _) -> RsId "BUILTIN_neg_real_TODO"
-  | RsApp (RsId "add_real", gens, _) -> RsId "BUILTIN_add_real_TODO"
-  | RsApp (RsId "sub_real", gens, _) -> RsId "BUILTIN_sub_real_TODO"
-  | RsApp (RsId "mult_real", gens, _) -> RsId "BUILTIN_mult_real_TODO"
-  | RsApp (RsId "div_real", gens, _) -> RsId "BUILTIN_div_real_TODO"
-  | RsApp (RsId "lt_real", gens, _) -> RsId "BUILTIN_lt_real_TODO"
-  | RsApp (RsId "gt_real", gens, _) -> RsId "BUILTIN_gt_real_TODO"
-  | RsApp (RsId "lteq_real", gens, _) -> RsId "BUILTIN_lteq_real_TODO"
-  | RsApp (RsId "gteq_real", gens, _) -> RsId "BUILTIN_gteq_real_TODO"
+  | RsApp (RsId "length", _gens, _) -> RsId "BUILTIN_length_TODO"
+  | RsApp (RsId "replicate_bits", _gens, _) -> RsId "BUILTIN_replicate_bits_TODO"
+  | RsApp (RsId "count_leading_zeros", _gens, _) ->
+    RsId "BUILTIN_count_leading_zeros_TODO"
+  | RsApp (RsId "eq_real", _gens, _) -> RsId "BUILTIN_eq_real_TODO"
+  | RsApp (RsId "neg_real", _gens, _) -> RsId "BUILTIN_neg_real_TODO"
+  | RsApp (RsId "add_real", _gens, _) -> RsId "BUILTIN_add_real_TODO"
+  | RsApp (RsId "sub_real", _gens, _) -> RsId "BUILTIN_sub_real_TODO"
+  | RsApp (RsId "mult_real", _gens, _) -> RsId "BUILTIN_mult_real_TODO"
+  | RsApp (RsId "div_real", _gens, _) -> RsId "BUILTIN_div_real_TODO"
+  | RsApp (RsId "lt_real", _gens, _) -> RsId "BUILTIN_lt_real_TODO"
+  | RsApp (RsId "gt_real", _gens, _) -> RsId "BUILTIN_gt_real_TODO"
+  | RsApp (RsId "lteq_real", _gens, _) -> RsId "BUILTIN_lteq_real_TODO"
+  | RsApp (RsId "gteq_real", _gens, _) -> RsId "BUILTIN_gteq_real_TODO"
   | RsApp (RsId "concat_str", gens, [ s1; s2 ]) ->
     RsApp (RsId "format!", gens, [ RsId "\"{}{}\""; s1; s2 ])
     (* There is a bug with hoisting here *)
   | RsApp (RsId "print_bits", gens, e) -> RsApp (RsId "print_output", gens, e)
-  | RsApp (RsId "string_of_bits", gens, _) -> RsId "BUILTIN_string_of_bits_TODO"
+  | RsApp (RsId "string_of_bits", _gens, _) -> RsId "BUILTIN_string_of_bits_TODO"
   | RsApp (RsId "dec_str", gens, e) ->
     RsApp (RsId "dec_str", gens, e) (* Handled by an external lib *)
   | RsApp (RsId "hex_str", gens, e) ->
     RsApp (RsId "hex_str", gens, e) (* Handled by an external lib *)
-  | RsApp (RsId "hex_str_upper", gens, _) -> RsId "BUILTIN_hex_str_upper_TODO"
-  | RsApp (RsId "sail_assert", gens, _) -> RsId "BUILTIN_sail_assert_TODO"
-  | RsApp (RsId "reg_deref", gens, _) -> RsId "BUILTIN_reg_deref_TODO"
-  | RsApp (RsId "sail_cons", gens, _) -> RsId "BUILTIN_sail_cons_TODO"
-  | RsApp (RsId "eq_anything", gens, _) -> RsId "BUILTIN_eq_anything_TODO"
-  | RsApp (RsId "id", gens, _) -> RsId "BUILTIN_id_TODO"
-  | RsApp (RsId "gteq_int", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopGe, e2)
-  | RsApp (RsId "lt_int", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopLt, e2)
-  | RsApp (RsId "gt_int", gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopGt, e2)
-  | RsApp (RsId "internal_error", gens, [ file; line; message ]) ->
+  | RsApp (RsId "hex_str_upper", _gens, _) -> RsId "BUILTIN_hex_str_upper_TODO"
+  | RsApp (RsId "sail_assert", _gens, _) -> RsId "BUILTIN_sail_assert_TODO"
+  | RsApp (RsId "reg_deref", _gens, _) -> RsId "BUILTIN_reg_deref_TODO"
+  | RsApp (RsId "sail_cons", _gens, _) -> RsId "BUILTIN_sail_cons_TODO"
+  | RsApp (RsId "eq_anything", _gens, _) -> RsId "BUILTIN_eq_anything_TODO"
+  | RsApp (RsId "id", _gens, _) -> RsId "BUILTIN_id_TODO"
+  | RsApp (RsId "gteq_int", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopGe, e2)
+  | RsApp (RsId "lt_int", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopLt, e2)
+  | RsApp (RsId "gt_int", _gens, [ e1; e2 ]) -> RsBinop (e1, RsBinopGt, e2)
+  | RsApp (RsId "internal_error", _gens, [ file; line; message ]) ->
     RsApp (RsId "panic!", [], [ RsLit (RsLitStr "{}, l {}: {}"); file; line; message ])
-  | RsApp (RsId id, gens, _) when SSet.mem id unsupported_fun -> RsLit RsLitUnit
+  | RsApp (RsId id, _gens, _) when SSet.mem id unsupported_fun -> RsLit RsLitUnit
   | _ -> exp
 ;;
 
@@ -835,7 +837,7 @@ let rec rename_in_exp (rn : string * string) (exp : rs_exp) : rs_exp =
   | RsTodo s -> RsTodo s
 
 and rename_in_pexp (rn : string * string) (pexp : rs_pexp) : rs_pexp =
-  let id, new_id = rn in
+  let id, _new_id = rn in
   match (pexp : rs_pexp) with
   (* First case: the ID is being shadowed, stop renaming at that point *)
   | (RsPexp (pat, _) | RsPexpWhen (pat, _, _)) when SSet.mem id (ids_of_pat pat) -> pexp
@@ -865,15 +867,15 @@ and rename_in_lexp (rn : string * string) (lexp : rs_lexp) : rs_lexp =
 let rec should_hoist_exp (is_nested : bool) (exp : rs_exp) : bool =
   let core_ctx = RsId core_ctx in
   match exp with
-  | RsApp (exp, generics, args) -> List.mem core_ctx args || should_hoist_args args
+  | RsApp (_exp, _generics, args) -> List.mem core_ctx args || should_hoist_args args
   | RsMethodApp app ->
     should_hoist_exp true app.exp
     || List.mem core_ctx app.args
     || should_hoist_args app.args
   | RsIf (_, _, _) -> true
-  | RsField (e, e2) -> should_hoist_exp true e
-  | RsBinop (e1, op, e2) -> should_hoist_exp true e1 || should_hoist_exp true e2
-  | RsUnop (op, e) -> should_hoist_exp true e
+  | RsField (e, _e2) -> should_hoist_exp true e
+  | RsBinop (e1, _op, e2) -> should_hoist_exp true e1 || should_hoist_exp true e2
+  | RsUnop (_op, e) -> should_hoist_exp true e
   | RsMatch _ -> true
   | e when e = core_ctx && is_nested -> true
   | _ -> false
@@ -977,7 +979,7 @@ let rec hoist_let_exp (exp : rs_exp) : rs_exp * (rs_pat * rs_exp) list =
   | _ -> exp, []
 ;;
 
-let pexp_hoister (ctx : context) (pexp : rs_pexp) : rs_pexp =
+let pexp_hoister (_ctx : context) (pexp : rs_pexp) : rs_pexp =
   match pexp with
   | RsPexpWhen (pat, cond, exp) ->
     let cond, defs = hoist_let_exp cond in
@@ -1017,7 +1019,7 @@ let expr_hoister (ctx : context) (exp : rs_exp) : rs_exp =
   | _ -> exp
 ;;
 
-let obj_hoister (ctx : context) (obj : rs_obj) : rs_obj =
+let obj_hoister (_ctx : context) (obj : rs_obj) : rs_obj =
   (* For each rust object we reset the counter
        This makes the IDs of variables more stable, as a change in a function
        doesn't rename variables in another *)
@@ -1088,7 +1090,7 @@ let virt_context_call_graph = { func = is_sail_context_needed }
 (* Adds a virtual context as first argument to all functions.                 *)
 (* —————————————————————————————————————————————————————————————————————————— *)
 
-let sail_context_inserter (ctx : context) (func : rs_fn) : rs_fn =
+let sail_context_inserter (_ctx : context) (func : rs_fn) : rs_fn =
   if func.use_sail_ctx
   then
     { func with
@@ -1109,8 +1111,8 @@ let virt_context_transform = { func = sail_context_inserter }
 let add_namespace_to_arg_pats (ctx : context) (func : rs_fn) : rs_fn =
   let rec get_namespace enum enum_list =
     match enum_list with
-    | (k, v) :: tail when k = enum -> Some v
-    | (k, v) :: tail -> get_namespace enum tail
+    | (k, v) :: _ when k = enum -> Some v
+    | _ :: tail -> get_namespace enum tail
     | [] -> None
   in
   (* Add the proper enum namespace to all enum pattern argument, leave other unchanged *)
@@ -1141,7 +1143,7 @@ let enum_arg_namespace : func_transform = { func = add_namespace_to_arg_pats }
 (* scattered function.                                                        *)
 (* —————————————————————————————————————————————————————————————————————————— *)
 
-let fix_scattered_func (ctx : context) (func : rs_fn) : rs_fn =
+let fix_scattered_func (_ctx : context) (func : rs_fn) : rs_fn =
   let get_if_missing_arg arg =
     match arg with
     | RsPatId x when String.starts_with ~prefix:"missing_arg_" x -> Some x
@@ -1161,16 +1163,16 @@ let fix_scattered_func : func_transform = { func = fix_scattered_func }
 
 (* ———————————————————————————— Fix Generic Type ———————————————————————————— *)
 
-let fix_generic_type_func (ctx : context) (func : rs_fn) : rs_fn =
+let fix_generic_type_func (_ctx : context) (func : rs_fn) : rs_fn =
   let rec get_array_type_vars (typs : rs_type list) =
     match typs with
     | RsTypArray (_, RsTypParamTyp (RsTypId n)) :: tail -> n :: get_array_type_vars tail
-    | head :: tail -> get_array_type_vars tail
+    | _ :: tail -> get_array_type_vars tail
     | [] -> []
   in
   let set_array_generic_types (should_set : string list) (generic : rs_generic) =
     match generic with
-    | RsGenConst (s, typ) when List.mem s should_set -> RsGenConst (s, "usize")
+    | RsGenConst (s, _typ) when List.mem s should_set -> RsGenConst (s, "usize")
     | _ -> generic
   in
   let array_type_vars =
@@ -1196,7 +1198,7 @@ let fix_generic_type : func_transform = { func = fix_generic_type_func }
     Yet if 'with is not part of an argument or return type (such as a vector
     width), then it has no impact on the Rust code gen, and the Sail
     front-end already enforced the invariant.**)
-let remove_unused_generics_func (ctx : context) (func : rs_fn) : rs_fn =
+let remove_unused_generics_func (_ctx : context) (func : rs_fn) : rs_fn =
   let fn_type = func.signature in
   (* Collect all the used generics *)
   let args_generics =
@@ -1235,7 +1237,7 @@ let link_generics_to_args_exp (ctx : context) (exp : rs_exp) : rs_exp =
   (* Spcial case for well known Sail functions *)
   | RsApp (RsId id, [], args) when id = "subrange_bits" ->
     (match args with
-     | [ vec; RsLit (RsLitNum vec_end); RsLit (RsLitNum vec_start) ] ->
+     | [ _vec; RsLit (RsLitNum vec_end); RsLit (RsLitNum vec_start) ] ->
        let out_size = Big_int.add (Big_int.sub vec_end vec_start) (Big_int.of_int 1) in
        RsApp (RsId id, [ "_"; Big_int.to_string out_size ], args)
      | _ -> exp)
@@ -1243,7 +1245,7 @@ let link_generics_to_args_exp (ctx : context) (exp : rs_exp) : rs_exp =
     (* NOTE: This is a RISC-V specific function. If we ever need more
          we should factor them out into the rv64 arch layer. *)
     (match args with
-     | [ RsLit (RsLitNum size); value ] ->
+     | [ RsLit (RsLitNum size); _value ] ->
        RsApp (RsId id, [ Big_int.to_string size ], args)
      | _ -> exp)
   | RsApp (RsId fn, [], args) when SMap.mem fn ctx.defs.fun_typs ->
@@ -1324,7 +1326,7 @@ let should_be_const (body : rs_exp) : bool =
   | _ -> false
 ;;
 
-let const_functions (ctx : context) (func : rs_fn) : rs_fn =
+let const_functions (_ctx : context) (func : rs_fn) : rs_fn =
   { func with const = should_be_const func.body }
 ;;
 
@@ -1344,7 +1346,7 @@ let remove_illegal_operator_char str =
   str
 ;;
 
-let operator_rewriter_func (ctx : context) (func : rs_fn) : rs_fn =
+let operator_rewriter_func (_ctx : context) (func : rs_fn) : rs_fn =
   { func with name = remove_illegal_operator_char func.name }
 ;;
 
@@ -1352,7 +1354,7 @@ let operator_rewriter = { func = operator_rewriter_func }
 
 (* ———————————————————————— Operator rewriter caller side  ————————————————————————— *)
 
-let expr_operator_rewriter (ctx : context) (exp : rs_exp) : rs_exp =
+let expr_operator_rewriter (_ctx : context) (exp : rs_exp) : rs_exp =
   match exp with
   | RsApp (RsId id, generics, args) ->
     RsApp (RsId (remove_illegal_operator_char id), generics, args)
@@ -1383,7 +1385,7 @@ let remove_atom_from_signature (func_sig : rs_fn_type) : rs_fn_type =
   { func_sig with args; ret }
 ;;
 
-let atom_rewriter_func (ctx : context) (func : rs_fn) : rs_fn =
+let atom_rewriter_func (_ctx : context) (func : rs_fn) : rs_fn =
   { func with signature = remove_atom_from_signature func.signature }
 ;;
 
@@ -1482,16 +1484,16 @@ let transform_basic_types_exp (ctx : context) (exp : rs_exp) : rs_exp =
 ;;
 
 (* TODO: Should we apply the same logic in lexp here? *)
-let transform_basic_types_lexp (ctx : context) (lexp : rs_lexp) : rs_lexp =
+let transform_basic_types_lexp (_ctx : context) (lexp : rs_lexp) : rs_lexp =
   match lexp with
   | RsLexpId "priv" -> RsLexpId "_priv_"
   | RsLexpId "super" -> RsLexpId "_super_"
   | _ -> lexp
 ;;
 
-let transform_basic_types_pexp (ctx : context) (pexp : rs_pexp) : rs_pexp = pexp
+let transform_basic_types_pexp (_ctx : context) (pexp : rs_pexp) : rs_pexp = pexp
 
-let transform_basic_types_type (ctx : context) (typ : rs_type) : rs_type =
+let transform_basic_types_type (_ctx : context) (typ : rs_type) : rs_type =
   match typ with
   | RsTypId "string" -> RsTypId "&\'static str"
   | RsTypId "int" -> int_typ
@@ -1502,7 +1504,7 @@ let transform_basic_types_type (ctx : context) (typ : rs_type) : rs_type =
   | _ -> typ
 ;;
 
-let transform_basic_types_pat (ctx : context) (pat : rs_pat) : rs_pat =
+let transform_basic_types_pat (_ctx : context) (pat : rs_pat) : rs_pat =
   match pat with
   | RsPatId "priv" -> RsPatId "_priv_"
   | RsPatId "super" -> RsPatId "_super_"
@@ -1521,7 +1523,7 @@ let transform_basic_types : expr_type_transform =
 
 (* ———————————————————————— Wildcard inserter  ————————————————————————— *)
 
-let add_wildcard_match_expr (ctx : context) (exp : rs_exp) : rs_exp =
+let add_wildcard_match_expr (_ctx : context) (exp : rs_exp) : rs_exp =
   match exp with
   | RsMatch (exp, pexps) ->
     RsMatch
@@ -1562,7 +1564,7 @@ let sail_context_arg_inserter_exp (ctx : context) (exp : rs_exp) : rs_exp =
     when (not (SSet.mem app_id ctx.arch.external_func)) && not (is_enum app_id) ->
     (match ctx_fun app_id ctx with
      | Some fn when not fn.use_sail_ctx -> exp
-     | Some fn ->
+     | Some _fn ->
        let args = RsId core_ctx :: args in
        RsApp (RsId app_id, generics, args)
      | _ ->
@@ -1588,18 +1590,18 @@ let sail_context_arg_inserter : expr_type_transform =
 
 let filter_different_litterals (lit : Big_int.num) (pexp : rs_pexp) : bool =
   match pexp with
-  | RsPexp (RsPatTuple [ e; RsPatLit (RsLitNum n) ], e2) when n <> lit -> false
-  | RsPexpWhen (RsPatTuple [ e; RsPatLit (RsLitNum n) ], e2, e3) when n <> lit -> false
+  | RsPexp (RsPatTuple [ _e; RsPatLit (RsLitNum n) ], _e2) when n <> lit -> false
+  | RsPexpWhen (RsPatTuple [ _e; RsPatLit (RsLitNum n) ], _e2, _e3) when n <> lit -> false
   | _ -> true
 ;;
 
-let dead_code_remover_exp (ctx : context) (exp : rs_exp) : rs_exp =
+let dead_code_remover_exp (_ctx : context) (exp : rs_exp) : rs_exp =
   match exp with
   | RsMatch (RsTuple [ e; RsLit (RsLitNum n) ], pexps) ->
     RsMatch
       (RsTuple [ e; RsLit (RsLitNum n) ], List.filter (filter_different_litterals n) pexps)
   | RsIf
-      (RsBinop (RsLit (RsLitNum n1), RsBinopEq, RsLit (RsLitNum n2)), then_exp, else_exp)
+      (RsBinop (RsLit (RsLitNum n1), RsBinopEq, RsLit (RsLitNum n2)), _then_exp, else_exp)
     when n1 <> n2 ->
     RsIf
       ( RsBinop (RsLit (RsLitNum n1), RsBinopEq, RsLit (RsLitNum n2))
@@ -1638,7 +1640,8 @@ let is_supported_obj (ctx : context) (obj : rs_obj) : bool =
 
 let remove_unsupported_func_calls (ctx : context) (exp : rs_exp) : rs_exp =
   match exp with
-  | RsApp (RsId app_id, generics, args) when SSet.mem app_id ctx.arch.unsupported_func ->
+  | RsApp (RsId app_id, _generics, _args) when SSet.mem app_id ctx.arch.unsupported_func
+    ->
     let err_message = Printf.sprintf "Unsupported function: '%s'" app_id in
     RsApp (RsId "panic!", [], [ RsLit (RsLitStr err_message) ])
   | _ -> exp
@@ -1696,9 +1699,9 @@ let optimizer (ctx : context) (rust_program : rs_program) : rs_program =
   let get_num_constants (RsProg obj : rs_program) : (string * Big_int.num) list =
     let rec constants obj =
       match obj with
-      | RsConst { value = RsLit (RsLitNum n); name } :: tail ->
+      | RsConst { value = RsLit (RsLitNum n); name; typ = _ } :: tail ->
         (name, n) :: constants tail
-      | head :: tail -> constants tail
+      | _ :: tail -> constants tail
       | [] -> []
     in
     constants obj
@@ -1710,7 +1713,7 @@ let optimizer (ctx : context) (rust_program : rs_program) : rs_program =
         (match fn.body with
          | RsLit lit | RsBlock [ RsLit lit ] -> (fn.name, RsLit lit) :: funs tail
          | _ -> funs tail)
-      | head :: tail -> funs tail
+      | _ :: tail -> funs tail
       | [] -> []
     in
     funs obj

--- a/sail_rust_backend/sail_plugin_rust.ml
+++ b/sail_rust_backend/sail_plugin_rust.ml
@@ -1,12 +1,6 @@
 open Libsail
-open Ast
 open Ast_util
-open Ast_defs
 open Interactive.State
-open Rust_transform
-open Rust_gen
-open Call_set
-open Context
 
 let opt_arch = ref Arch.Rv64.rv64
 
@@ -24,7 +18,7 @@ let rust_options =
   ]
 ;;
 
-let collect_rust_name_info ast =
+let _collect_rust_name_info ast =
   let open Ast in
   let open Ast_defs in
   let reserved = ref Util.StringSet.empty in


### PR DESCRIPTION
Currently, running `dune build` without the `--release` fail due to some warning treated as errors about unused variable. This PR fixes these warnings.

While working on fixing this issue, I noticed that some expression in the `call_set.ml` functions didn't use parameters and as such were probably not working correctly for these cases (`E_vector_subrange`, `E_vector_update`, `E_vector_append`, `E_cons`, `E_struct`, `E_struct_update`...), so this PR also contains a second commit which fixes this issue.

The function `ctx_union` was also unused inconsistently. It's main used was to merge two context and detect conflicting configurations, and this check was performed for each element on each union. I moved the check to only be made when adding a new configuration to a context, allowing contexts to be merged directly instead. 